### PR TITLE
Add utils to extract point data from non point features in geojson

### DIFF
--- a/src/modules/service/components/ServicePointList.tsx
+++ b/src/modules/service/components/ServicePointList.tsx
@@ -23,6 +23,7 @@ import {
   useGetFilteredFeatures,
 } from '@/modules/service/hooks/useGetFilteredFeatures'
 import {useServiceQuery} from '@/modules/service/service'
+import {convertGeometryToPoint} from '@/modules/service/utils/convertGeometryToPoint'
 import {ModuleSlug} from '@/modules/slugs'
 import {sortByDistanceToAddress} from '@/utils/sortByDistanceToAddress'
 
@@ -48,9 +49,7 @@ export const ServicePointList = ({
   const pointFeatures = useMemo(
     () =>
       geojson && 'features' in geojson
-        ? geojson?.features.filter(
-            (f): f is ServicePointFeature => f.geometry.type === 'Point',
-          )
+        ? convertGeometryToPoint(geojson.features)
         : [],
     [geojson],
   )

--- a/src/modules/service/utils/convertGeometryToPoint.test.ts
+++ b/src/modules/service/utils/convertGeometryToPoint.test.ts
@@ -1,7 +1,7 @@
-import type {Feature} from 'geojson'
+import type {ServiceGeoJSON} from '@/modules/service/types'
 import {convertGeometryToPoint} from '@/modules/service/utils/convertGeometryToPoint'
 
-const features: Record<string, Feature> = {
+const features: Record<string, ServiceGeoJSON['features'][number]> = {
   point: {
     type: 'Feature',
     id: 'point',
@@ -9,7 +9,7 @@ const features: Record<string, Feature> = {
       type: 'Point',
       coordinates: [4.88471, 52.370307, 999],
     },
-    properties: {},
+    properties: {aapp_title: ''},
   },
   lineString: {
     type: 'Feature',
@@ -21,7 +21,7 @@ const features: Record<string, Feature> = {
         [4.2, 52.2],
       ],
     },
-    properties: {},
+    properties: {aapp_title: ''},
   },
   polygon: {
     type: 'Feature',
@@ -35,7 +35,7 @@ const features: Record<string, Feature> = {
         ],
       ],
     },
-    properties: {},
+    properties: {aapp_title: ''},
   },
   multiPolygon: {
     type: 'Feature',
@@ -51,7 +51,7 @@ const features: Record<string, Feature> = {
         ],
       ],
     },
-    properties: {},
+    properties: {aapp_title: ''},
   },
   empty: {
     type: 'Feature',
@@ -60,7 +60,7 @@ const features: Record<string, Feature> = {
       type: 'GeometryCollection',
       geometries: [],
     },
-    properties: {},
+    properties: {aapp_title: ''},
   },
 }
 

--- a/src/modules/service/utils/convertGeometryToPoint.test.ts
+++ b/src/modules/service/utils/convertGeometryToPoint.test.ts
@@ -1,0 +1,114 @@
+import type {Feature} from 'geojson'
+import {convertGeometryToPoint} from '@/modules/service/utils/convertGeometryToPoint'
+
+const features: Record<string, Feature> = {
+  point: {
+    type: 'Feature',
+    id: 'point',
+    geometry: {
+      type: 'Point',
+      coordinates: [4.88471, 52.370307, 999],
+    },
+    properties: {},
+  },
+  lineString: {
+    type: 'Feature',
+    id: 'lineString',
+    geometry: {
+      type: 'LineString',
+      coordinates: [
+        [4.1, 52.1],
+        [4.2, 52.2],
+      ],
+    },
+    properties: {},
+  },
+  polygon: {
+    type: 'Feature',
+    id: 'polygon',
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [4.1, 52.1],
+          [4.2, 52.2],
+        ],
+      ],
+    },
+    properties: {},
+  },
+  multiPolygon: {
+    type: 'Feature',
+    id: 'multiPolygon',
+    geometry: {
+      type: 'MultiPolygon',
+      coordinates: [
+        [
+          [
+            [4.1, 52.1],
+            [4.2, 52.2],
+          ],
+        ],
+      ],
+    },
+    properties: {},
+  },
+  empty: {
+    type: 'Feature',
+    id: 'empty',
+    geometry: {
+      type: 'GeometryCollection',
+      geometries: [],
+    },
+    properties: {},
+  },
+}
+
+describe('convertGeometryToPoint', () => {
+  it('converts Point geometry to Point (keeps first two numbers)', () => {
+    const result = convertGeometryToPoint([features.point])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('point')
+    expect(result[0].geometry.type).toBe('Point')
+    expect(result[0].geometry.coordinates).toEqual([4.88471, 52.370307])
+  })
+
+  it('converts LineString geometry to a Point at its first position', () => {
+    const result = convertGeometryToPoint([features.lineString])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].geometry).toEqual({
+      type: 'Point',
+      coordinates: [4.1, 52.1],
+    })
+  })
+
+  it('converts Polygon geometry to a Point at its first ring first position', () => {
+    const result = convertGeometryToPoint([features.polygon])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].geometry.coordinates).toEqual([4.1, 52.1])
+  })
+
+  it('converts MultiPolygon geometry to a Point at its first polygon first ring first position', () => {
+    const result = convertGeometryToPoint([features.multiPolygon])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].geometry.coordinates).toEqual([4.1, 52.1])
+  })
+
+  it('ignores GeometryCollection features (no coordinates field)', () => {
+    const result = convertGeometryToPoint([features.empty])
+
+    expect(result).toEqual([])
+  })
+
+  it('returns only Points', () => {
+    const result = convertGeometryToPoint(Object.values(features))
+
+    expect(Array.from(new Set(result.map(r => r.geometry.type)))).toEqual([
+      'Point',
+    ])
+  })
+})

--- a/src/modules/service/utils/convertGeometryToPoint.ts
+++ b/src/modules/service/utils/convertGeometryToPoint.ts
@@ -15,7 +15,16 @@ export const convertGeometryToPoint = (features: Feature[]) =>
         }
       }
     })
-    .filter(
-      (f): f is ServicePointFeature =>
-        Boolean(f) && typeof f?.geometry.coordinates[0] === 'number',
-    )
+    .filter((f): f is ServicePointFeature => {
+      if (!f) {
+        return false
+      }
+
+      const {coordinates} = f.geometry
+
+      return (
+        coordinates.length >= 2 &&
+        Number.isFinite(coordinates[0]) &&
+        Number.isFinite(coordinates[1])
+      )
+    })

--- a/src/modules/service/utils/convertGeometryToPoint.ts
+++ b/src/modules/service/utils/convertGeometryToPoint.ts
@@ -1,8 +1,10 @@
 import type {ServicePointFeature} from '@/modules/service/types'
-import type {Feature} from 'geojson'
+import type {Feature, Geometry} from 'geojson'
 import {getFirstPosition} from '@/modules/service/utils/getFirstPosition'
 
-export const convertGeometryToPoint = (features: Feature[]) =>
+export const convertGeometryToPoint = (
+  features: Array<Feature<Geometry, ServicePointFeature['properties']>>,
+): ServicePointFeature[] =>
   features
     .map(f => {
       if (f.geometry && 'coordinates' in f.geometry) {

--- a/src/modules/service/utils/convertGeometryToPoint.ts
+++ b/src/modules/service/utils/convertGeometryToPoint.ts
@@ -5,7 +5,7 @@ import {getFirstPosition} from '@/modules/service/utils/getFirstPosition'
 export const convertGeometryToPoint = (features: Feature[]) =>
   features
     .map(f => {
-      if ('coordinates' in f.geometry) {
+      if (f.geometry && 'coordinates' in f.geometry) {
         return {
           ...f,
           geometry: {

--- a/src/modules/service/utils/convertGeometryToPoint.ts
+++ b/src/modules/service/utils/convertGeometryToPoint.ts
@@ -1,9 +1,8 @@
-import type {ServicePointFeature} from '@/modules/service/types'
-import type {Feature, Geometry} from 'geojson'
+import type {ServiceGeoJSON, ServicePointFeature} from '@/modules/service/types'
 import {getFirstPosition} from '@/modules/service/utils/getFirstPosition'
 
 export const convertGeometryToPoint = (
-  features: Array<Feature<Geometry, ServicePointFeature['properties']>>,
+  features: ServiceGeoJSON['features'],
 ): ServicePointFeature[] =>
   features
     .map(f => {

--- a/src/modules/service/utils/convertGeometryToPoint.ts
+++ b/src/modules/service/utils/convertGeometryToPoint.ts
@@ -5,23 +5,23 @@ export const convertGeometryToPoint = (
   features: ServiceGeoJSON['features'],
 ): ServicePointFeature[] =>
   features
-    .map(f => {
-      if (f.geometry && 'coordinates' in f.geometry) {
+    .map(feature => {
+      if (feature.geometry && 'coordinates' in feature.geometry) {
         return {
-          ...f,
+          ...feature,
           geometry: {
             type: 'Point',
-            coordinates: getFirstPosition(f.geometry.coordinates),
+            coordinates: getFirstPosition(feature.geometry.coordinates),
           },
         }
       }
     })
-    .filter((f): f is ServicePointFeature => {
-      if (!f) {
+    .filter((feature): feature is ServicePointFeature => {
+      if (!feature) {
         return false
       }
 
-      const {coordinates} = f.geometry
+      const {coordinates} = feature.geometry
 
       return (
         coordinates.length >= 2 &&

--- a/src/modules/service/utils/convertGeometryToPoint.ts
+++ b/src/modules/service/utils/convertGeometryToPoint.ts
@@ -1,0 +1,21 @@
+import type {ServicePointFeature} from '@/modules/service/types'
+import type {Feature} from 'geojson'
+import {getFirstPosition} from '@/modules/service/utils/getFirstPosition'
+
+export const convertGeometryToPoint = (features: Feature[]) =>
+  features
+    .map(f => {
+      if ('coordinates' in f.geometry) {
+        return {
+          ...f,
+          geometry: {
+            type: 'Point',
+            coordinates: getFirstPosition(f.geometry.coordinates),
+          },
+        }
+      }
+    })
+    .filter(
+      (f): f is ServicePointFeature =>
+        Boolean(f) && typeof f?.geometry.coordinates[0] === 'number',
+    )

--- a/src/modules/service/utils/getFirstPosition.test.ts
+++ b/src/modules/service/utils/getFirstPosition.test.ts
@@ -1,0 +1,57 @@
+import {getFirstPosition} from '@/modules/service/utils/getFirstPosition'
+
+describe('getFirstPosition', () => {
+  it('should return a Position regardless of how deeply nested the input is.', () => {
+    const position1 = [1, 2]
+    const position2 = [[1, 2]]
+    const position3 = [[[1, 2]]]
+    const position4 = [[[[1, 2]]]]
+
+    expect(getFirstPosition(position1)).toEqual([1, 2])
+    expect(getFirstPosition(position2)).toEqual([1, 2])
+    expect(getFirstPosition(position3)).toEqual([1, 2])
+    expect(getFirstPosition(position4)).toEqual([1, 2])
+  })
+
+  it('should return only 2 entries', () => {
+    const position1 = [1, 2, 3, 4]
+    const position2 = [[1, 2, 3, 4]]
+    const position3 = [[[1, 2, 3, 4]]]
+    const position4 = [[[[1, 2, 3, 4]]]]
+
+    expect(getFirstPosition(position1)).toEqual([1, 2])
+    expect(getFirstPosition(position2)).toEqual([1, 2])
+    expect(getFirstPosition(position3)).toEqual([1, 2])
+    expect(getFirstPosition(position4)).toEqual([1, 2])
+  })
+
+  it('should return only 2 entries, from the first entry in the nested array', () => {
+    const position1 = [1, 2]
+    const position2 = [
+      [1, 2],
+      [3, 4],
+    ]
+    const position3 = [
+      [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ],
+    ]
+    const position4 = [
+      [
+        [
+          [1, 2],
+          [3, 4],
+          [5, 6],
+          [7, 8],
+        ],
+      ],
+    ]
+
+    expect(getFirstPosition(position1)).toEqual([1, 2])
+    expect(getFirstPosition(position2)).toEqual([1, 2])
+    expect(getFirstPosition(position3)).toEqual([1, 2])
+    expect(getFirstPosition(position4)).toEqual([1, 2])
+  })
+})

--- a/src/modules/service/utils/getFirstPosition.ts
+++ b/src/modules/service/utils/getFirstPosition.ts
@@ -3,11 +3,14 @@ import type {Position} from 'geojson'
 export const getFirstPosition = (
   positions: Position | Position[] | Position[][] | Position[][][],
 ): Position => {
-  let current: Position | Position[] | Position[][] | Position[][][] = positions
+  const firstElement = (positions as unknown as Array<unknown>)[0]
 
-  while (Array.isArray(current[0])) {
-    current = current[0] as Position[] | Position[][] | Position[][][]
+  if (Array.isArray(firstElement)) {
+    return getFirstPosition(
+      firstElement as Position | Position[] | Position[][] | Position[][][],
+    )
   }
 
-  return (current as Position).slice(0, 2)
+  return (positions as Position).slice(0, 2)
 }
+

--- a/src/modules/service/utils/getFirstPosition.ts
+++ b/src/modules/service/utils/getFirstPosition.ts
@@ -1,0 +1,5 @@
+import type {Position} from 'geojson'
+
+export const getFirstPosition = (
+  positions: Position | Position[] | Position[][] | Position[][][],
+): Position => positions.flat(3).slice(0, 2)

--- a/src/modules/service/utils/getFirstPosition.ts
+++ b/src/modules/service/utils/getFirstPosition.ts
@@ -2,4 +2,12 @@ import type {Position} from 'geojson'
 
 export const getFirstPosition = (
   positions: Position | Position[] | Position[][] | Position[][][],
-): Position => positions.flat(3).slice(0, 2)
+): Position => {
+  let current: Position | Position[] | Position[][] | Position[][][] = positions
+
+  while (Array.isArray(current[0])) {
+    current = current[0] as Position[] | Position[][] | Position[][][]
+  }
+
+  return (current as Position).slice(0, 2)
+}

--- a/src/modules/service/utils/getFirstPosition.ts
+++ b/src/modules/service/utils/getFirstPosition.ts
@@ -13,4 +13,3 @@ export const getFirstPosition = (
 
   return (positions as Position).slice(0, 2)
 }
-


### PR DESCRIPTION
# Changes

The features from the geojson that couldn't be processed as points showed a 'NaN' value in the ServicePointList view, where distance to point should be rendered. 

This PR aims to extract point data from polygons, multipolygons, and linestrings (and other feature data) to process them as points.

## Test instructions

## Other notes

