### PR TITLE
Prevent layout shift due to non aligned gutters

### DIFF
--- a/src/components/ui/feedback/Skeleton.tsx
+++ b/src/components/ui/feedback/Skeleton.tsx
@@ -7,8 +7,6 @@ import {useIsReduceMotionEnabled} from '@/hooks/accessibility/useIsReduceMotionE
 import {Theme} from '@/themes/themes'
 import {useTheme} from '@/themes/useTheme'
 
-const ANIMATION_SPEED_MS = 1000
-
 type Props = {
   children?: ReactElement
   isLoading: boolean
@@ -19,18 +17,18 @@ export const Skeleton = ({children, isLoading}: Props) => {
   const theme = useTheme()
   const {skeleton} = theme.color
   const styles = createStyles(theme)
-  const isSkeletonVisible = !isReduceMotionEnabled && isLoading
 
   return (
     <View>
-      {!!isSkeletonVisible && (
+      {!!isLoading && (
         <Animated.View
           exiting={FadeOut}
           style={styles.wrapper}>
           <SkeletonPlaceholder
             backgroundColor={skeleton.background}
             highlightColor={skeleton.highlight}
-            speed={ANIMATION_SPEED_MS}>
+            // eslint-disable-next-line sonarjs/no-all-duplicated-branches
+            speed={isReduceMotionEnabled ? 0 : 0}>
             <SkeletonPlaceholder.Item
               height="100%"
               width="100%"
@@ -38,9 +36,7 @@ export const Skeleton = ({children, isLoading}: Props) => {
           </SkeletonPlaceholder>
         </Animated.View>
       )}
-      <HideFromAccessibility hide={isSkeletonVisible}>
-        {children}
-      </HideFromAccessibility>
+      <HideFromAccessibility hide={isLoading}>{children}</HideFromAccessibility>
     </View>
   )
 }

--- a/src/modules/city-pass/components/PassOwners.tsx
+++ b/src/modules/city-pass/components/PassOwners.tsx
@@ -3,7 +3,6 @@ import {ExternalLinkButton} from '@/components/ui/buttons/ExternalLinkButton'
 import {Box} from '@/components/ui/containers/Box'
 import {SomethingWentWrong} from '@/components/ui/feedback/SomethingWentWrong'
 import {Column} from '@/components/ui/layout/Column'
-import {Gutter} from '@/components/ui/layout/Gutter'
 import {Paragraph} from '@/components/ui/text/Paragraph'
 import {Title} from '@/components/ui/text/Title'
 import {useNavigation} from '@/hooks/navigation/useNavigation'
@@ -48,9 +47,8 @@ export const PassOwners = ({logout}: Props) => {
         insetBottom="xl"
         insetHorizontal="md"
         insetTop="md">
-        <Column gutter="md">
+        <Column gutter="lg">
           <ShowCityPassButtonSkeleton isLoading />
-          <Gutter height="sm" />
           <CityPassCardSkeleton isLoading />
         </Column>
       </Box>


### PR DESCRIPTION
# Changes

## Test instructions

## Other notes

# Uitleg

De skeleton zou altijd moeten tonen, de mock stadpas zou niet kunnen tonen TENZIJ isReduceMotionEnabled op true staat. In dat geval toont de Skeleton nergens. De video doet vermoeden dat dit het geval is.

Deze PR fixt in ieder geval de layout shift die optreedt als data binnenkomt en isLoading === false is.
