### PR TITLE
Map: make rainbow LineString generic

### DIFF
--- a/src/components/features/map/line-string/LineString.tsx
+++ b/src/components/features/map/line-string/LineString.tsx
@@ -60,7 +60,7 @@ export const LineString = ({
       )}
       <ArrowMarkers
         coordinates={latLngCoordinates}
-        size={colors ? 'ml' : 'md'}
+        size={colors?.length ? 'ml' : 'md'}
       />
     </>
   )

--- a/src/components/features/map/line-string/LineString.tsx
+++ b/src/components/features/map/line-string/LineString.tsx
@@ -42,7 +42,7 @@ export const LineString = ({
 
   return (
     <>
-      {Array.isArray(colors) ? (
+      {colors?.length ? (
         <RainbowPolyLine
           colors={colors}
           latLngCoordinates={latLngCoordinates}

--- a/src/components/features/map/line-string/LineString.tsx
+++ b/src/components/features/map/line-string/LineString.tsx
@@ -8,13 +8,13 @@ import {
 } from '@/utils/transform/coordinatesToLatLng'
 
 type Props = {
+  colors?: string[]
   coordinates: Position | Position[] | Position[][] | Position[][][]
   id: string | number
   onPress: (id: string | number) => void
   region: Region | undefined
   strokeColor?: number | string | null
   strokeWidth?: number | null
-  type: 'rainbow' | 'default'
 }
 
 export const LineString = ({
@@ -24,7 +24,7 @@ export const LineString = ({
   strokeColor,
   strokeWidth,
   region,
-  type,
+  colors,
 }: Props) => {
   const latLngCoordinates = useMemo(
     () => coordinatesToLatLng(coordinates),
@@ -42,8 +42,9 @@ export const LineString = ({
 
   return (
     <>
-      {type === 'rainbow' ? (
+      {Array.isArray(colors) ? (
         <RainbowPolyLine
+          colors={colors}
           latLngCoordinates={latLngCoordinates}
           onPress={() => onPress(id)}
           region={region}
@@ -59,7 +60,7 @@ export const LineString = ({
       )}
       <ArrowMarkers
         coordinates={latLngCoordinates}
-        size={type === 'rainbow' ? 'ml' : 'md'}
+        size={colors ? 'ml' : 'md'}
       />
     </>
   )

--- a/src/components/features/map/line-string/RainbowPolyLine.tsx
+++ b/src/components/features/map/line-string/RainbowPolyLine.tsx
@@ -34,11 +34,7 @@ export const RainbowPolyLine = ({
           key={index}
           onPress={onPress}
           strokeColor={color}
-          strokeWidth={
-            index <= colors.length
-              ? strokeWidth
-              : strokeWidth + 1 / colors.length
-          }
+          strokeWidth={strokeWidth}
           tappable
         />
       ))}

--- a/src/components/features/map/line-string/RainbowPolyLine.tsx
+++ b/src/components/features/map/line-string/RainbowPolyLine.tsx
@@ -1,12 +1,13 @@
 import {Polyline, type LatLng, type Region} from 'react-native-maps'
+import {calculateOffsetFactor} from '@/components/features/map/line-string/calculateOffsetFactor'
 import {calculateOffsetLineString} from '@/components/features/map/line-string/calculateOffsetLineString'
 
 type Props = {
+  colors?: string[]
   latLngCoordinates: LatLng[]
   onPress: () => void
   region: Region | undefined
 }
-const STROKE_WIDTH = 3
 
 const OFFSET_SCALE_FACTOR = 0.003
 
@@ -16,52 +17,31 @@ export const RainbowPolyLine = ({
   latLngCoordinates,
   region,
   onPress,
+  colors,
 }: Props) => {
+  const strokeWidth = 12 / (colors?.length || 1)
   const offsetSize =
     OFFSET_SCALE_FACTOR * (region?.latitudeDelta || DEFAULT_LATITUDE_DELTA)
 
   return (
     <>
-      <Polyline
-        coordinates={calculateOffsetLineString(
-          latLngCoordinates,
-          1.5 * offsetSize,
-        )}
-        onPress={onPress}
-        strokeColor={'#ff0000'}
-        strokeWidth={STROKE_WIDTH}
-        tappable
-      />
-      <Polyline
-        coordinates={calculateOffsetLineString(
-          latLngCoordinates,
-          0.5 * offsetSize,
-        )}
-        onPress={onPress}
-        strokeColor={'#ffc400'}
-        strokeWidth={STROKE_WIDTH}
-        tappable
-      />
-      <Polyline
-        coordinates={calculateOffsetLineString(
-          latLngCoordinates,
-          -0.5 * offsetSize,
-        )}
-        onPress={onPress}
-        strokeColor={'#00bf07'}
-        strokeWidth={STROKE_WIDTH}
-        tappable
-      />
-      <Polyline
-        coordinates={calculateOffsetLineString(
-          latLngCoordinates,
-          -1.5 * offsetSize,
-        )}
-        onPress={onPress}
-        strokeColor={'#004ffb'}
-        strokeWidth={STROKE_WIDTH - 1}
-        tappable
-      />
+      {colors?.map((color, index) => (
+        <Polyline
+          coordinates={calculateOffsetLineString(
+            latLngCoordinates,
+            calculateOffsetFactor(index, colors.length) * offsetSize,
+          )}
+          key={index}
+          onPress={onPress}
+          strokeColor={color}
+          strokeWidth={
+            index <= colors.length
+              ? strokeWidth
+              : strokeWidth + 1 / colors.length
+          }
+          tappable
+        />
+      ))}
     </>
   )
 }

--- a/src/components/features/map/line-string/calculateOffsetFactor.test.ts
+++ b/src/components/features/map/line-string/calculateOffsetFactor.test.ts
@@ -1,0 +1,62 @@
+import {calculateOffsetFactor} from '@/components/features/map/line-string/calculateOffsetFactor'
+
+describe('calculateOffsetFactor', () => {
+  it('should return 0 when index is the middle position in an odd-sized collection.', () => {
+    const result = calculateOffsetFactor(1, 3)
+
+    expect(result).toBe(0)
+  })
+
+  it('should return a negative factor for the first index.', () => {
+    const result = calculateOffsetFactor(0, 4)
+
+    expect(result).toBe(-1.5)
+  })
+
+  it('should return -0.5 when index is 2 of 4.', () => {
+    const result = calculateOffsetFactor(1, 4)
+
+    expect(result).toBe(-0.5)
+  })
+
+  it('should return a positive factor for the third of 4.', () => {
+    const result = calculateOffsetFactor(2, 4)
+
+    expect(result).toBe(0.5)
+  })
+  it('should return a positive factor for the last index.', () => {
+    const result = calculateOffsetFactor(3, 4)
+
+    expect(result).toBe(1.5)
+  })
+
+  it('should return Infinity when total is 0.', () => {
+    const result = calculateOffsetFactor(0, 0)
+
+    expect(result).toBe(Infinity)
+  })
+
+  it('should return Infinity when total is null.', () => {
+    const total = null as unknown as number
+
+    const result = calculateOffsetFactor(0, total)
+
+    expect(result).toBe(Infinity)
+  })
+
+  it('should return NaN when total is undefined.', () => {
+    const total = undefined as unknown as number
+
+    const result = calculateOffsetFactor(0, total)
+
+    expect(result).toBeNaN()
+  })
+
+  it('should return NaN when index is undefined.', () => {
+    const index = undefined as unknown as number
+
+    const result = calculateOffsetFactor(index, 4)
+
+    expect(result).toBeNaN()
+  })
+})

--- a/src/components/features/map/line-string/calculateOffsetFactor.ts
+++ b/src/components/features/map/line-string/calculateOffsetFactor.ts
@@ -1,0 +1,2 @@
+export const calculateOffsetFactor = (index: number, total: number): number =>
+  ((index + 0.5) / total) * 4 - 2

--- a/src/components/features/map/marker/CustomMarkerIcon.tsx
+++ b/src/components/features/map/marker/CustomMarkerIcon.tsx
@@ -74,7 +74,7 @@ export const CustomMarkerIcon = ({
           y2="100%">
           {gradientColors.map((color, index) => (
             <Stop
-              key={color}
+              key={`${color}-${index}`}
               //intentionally using index + 1 to avoid having a stop at 0% and 100% which would make the gradient not visible
               offset={`${((index + 1) / (gradientColors.length + 1)) * 100}%`}
               stopColor={color}

--- a/src/components/features/map/marker/CustomMarkerIcon.tsx
+++ b/src/components/features/map/marker/CustomMarkerIcon.tsx
@@ -59,7 +59,7 @@ export const CustomMarkerIcon = ({
   offset = DEFAULT_OFFSET,
 }: Props) => {
   const center = size / ((size / PATH_SIZE) * 2)
-  const gradientColors = colors?.length ? colors : ['#ffffff']
+  const gradientColors = colors?.length ? colors : []
 
   return (
     <Wrapper
@@ -86,7 +86,9 @@ export const CustomMarkerIcon = ({
         <Circle
           cx={center}
           cy={center}
-          fill={colors?.length ? 'url(#markerCircleRainbowGradient)' : circleColor}
+          fill={
+            colors?.length ? 'url(#markerCircleRainbowGradient)' : circleColor
+          }
           r={center}
         />
         <Path

--- a/src/components/features/map/marker/CustomMarkerIcon.tsx
+++ b/src/components/features/map/marker/CustomMarkerIcon.tsx
@@ -26,7 +26,12 @@ type WrapperProps = PropsWithChildren<TestProps & {size?: number}>
 
 type Props = {
   Wrapper?: ComponentType<WrapperProps>
-  icon: {circleColor?: string; path: string; pathColor?: string}
+  icon: {
+    circleColor?: string
+    colors?: string[]
+    path: string
+    pathColor?: string
+  }
   offset?: {x: number; y: number}
   size?: number
 } & TestProps
@@ -47,13 +52,14 @@ export const CustomMarkerIcon = ({
     pathColor = themes.light.color.text.default,
     path,
     circleColor = 'transparent',
+    colors,
   },
   testID,
   size = DEFAULT_SIZE,
   offset = DEFAULT_OFFSET,
 }: Props) => {
   const center = size / ((size / PATH_SIZE) * 2)
-  const isRainbowCircle = circleColor === 'rainbow'
+  const gradientColors = colors?.length ? colors : ['#ffffff']
 
   return (
     <Wrapper
@@ -66,39 +72,21 @@ export const CustomMarkerIcon = ({
           x2="100%"
           y1="0%"
           y2="100%">
-          <Stop
-            offset="0%"
-            stopColor="#ff0000"
-          />
-          <Stop
-            offset="20%"
-            stopColor="#ff0000"
-          />
-          <Stop
-            offset="40%"
-            stopColor="#ffc400"
-          />
-          <Stop
-            offset="60%"
-            stopColor="#00bf07"
-          />
-          <Stop
-            offset="80%"
-            stopColor="#004ffb"
-          />
-          <Stop
-            offset="100%"
-            stopColor="#004ffb"
-          />
+          {gradientColors.map((color, index) => (
+            <Stop
+              key={color}
+              //intentionally using index + 1 to avoid having a stop at 0% and 100% which would make the gradient not visible
+              offset={`${((index + 1) / (gradientColors.length + 1)) * 100}%`}
+              stopColor={color}
+            />
+          ))}
         </LinearGradient>
       </Defs>
       <G transform={`translate(${offset.x}, ${offset.y})`}>
         <Circle
           cx={center}
           cy={center}
-          fill={
-            isRainbowCircle ? 'url(#markerCircleRainbowGradient)' : circleColor
-          }
+          fill={colors ? 'url(#markerCircleRainbowGradient)' : circleColor}
           r={center}
         />
         <Path

--- a/src/components/features/map/marker/CustomMarkerIcon.tsx
+++ b/src/components/features/map/marker/CustomMarkerIcon.tsx
@@ -86,7 +86,7 @@ export const CustomMarkerIcon = ({
         <Circle
           cx={center}
           cy={center}
-          fill={colors ? 'url(#markerCircleRainbowGradient)' : circleColor}
+          fill={colors?.length ? 'url(#markerCircleRainbowGradient)' : circleColor}
           r={center}
         />
         <Path

--- a/src/modules/service/components/ServiceMapLayerSwitch.tsx
+++ b/src/modules/service/components/ServiceMapLayerSwitch.tsx
@@ -1,7 +1,6 @@
 import type {
   ServiceMapResponse,
   ServiceMapResponseFilter,
-  ServiceMapResponseIcon,
 } from '@/modules/service/types'
 import {Switch} from '@/components/ui/forms/Switch'
 import {Row} from '@/components/ui/layout/Row'
@@ -22,14 +21,7 @@ export const ServiceMapLayerSwitch = ({
   isActive,
 }: Props) => {
   const {icon_label, label} = layer
-  const icon = icon_label
-    ? icon_label === 'canal_parade'
-      ? ({
-          ...icons?.[icon_label],
-          circle_color: 'rainbow',
-        } as ServiceMapResponseIcon)
-      : icons?.[icon_label]
-    : undefined
+  const icon = icon_label ? icons?.[icon_label] : undefined
 
   return (
     <Switch

--- a/src/modules/service/components/ServicePointCustomIcon.tsx
+++ b/src/modules/service/components/ServicePointCustomIcon.tsx
@@ -7,7 +7,7 @@ type Props = {
 } & TestProps
 
 export const ServicePointCustomIcon = ({
-  icon: {path_color, path, circle_color},
+  icon: {path_color, path, circle_color, colors},
   testID,
 }: Props) => (
   <CustomMarkerIcon
@@ -15,6 +15,7 @@ export const ServicePointCustomIcon = ({
       path,
       pathColor: path_color,
       circleColor: circle_color,
+      colors,
     }}
     testID={testID}
   />

--- a/src/modules/service/components/ServicePointMap.tsx
+++ b/src/modules/service/components/ServicePointMap.tsx
@@ -72,6 +72,11 @@ export const ServicePointMap = ({id: serviceId, onMapElementPress}: Props) => {
       {!!lineStrings?.length &&
         lineStrings.map((feature, index) => (
           <LineString
+            colors={
+              feature.properties.aapp_icon_type
+                ? icons_to_include?.[feature.properties.aapp_icon_type]?.colors
+                : undefined
+            }
             coordinates={
               'coordinates' in feature.geometry
                 ? feature.geometry.coordinates
@@ -86,11 +91,6 @@ export const ServicePointMap = ({id: serviceId, onMapElementPress}: Props) => {
               feature.properties['stroke-width']
                 ? Number(feature.properties['stroke-width'])
                 : null
-            }
-            type={
-              feature.properties.aapp_icon_type === 'canal_parade'
-                ? 'rainbow'
-                : 'default'
             }
           />
         ))}

--- a/src/modules/service/service.ts
+++ b/src/modules/service/service.ts
@@ -30,6 +30,22 @@ export const serviceApi = baseApi.injectEndpoints({
         slug: ModuleSlug.service,
         url: `/maps/${serviceId}`,
       }),
+      transformResponse: (response: ServiceMapResponse) => {
+        if (response.icons_to_include?.canal_parade) {
+          return {
+            ...response,
+            icons_to_include: {
+              ...response.icons_to_include,
+              canal_parade: {
+                ...response.icons_to_include.canal_parade,
+                colors: ['#ff0000', '#ffc400', '#00bf07', '#004ffb'],
+              },
+            },
+          }
+        } else {
+          return response
+        }
+      },
     }),
   }),
   overrideExisting: false,

--- a/src/modules/service/types.ts
+++ b/src/modules/service/types.ts
@@ -77,6 +77,7 @@ export type ServiceMapResponseFilter<
 }
 export type ServiceMapResponseIcon = {
   circle_color: string
+  colors?: string[]
   path: string
   path_color: string
 }


### PR DESCRIPTION
# Changes

LineStrings can now get multicolor stroke by passing a colors prop to the icon.
This will also be represented in the map layers, legend and the list view

## Test instructions

## Other notes

GitHub Copilot was used in writing the code
