### PR TITLE
Boat-charging: refactor new session form to react-hook-form

### DIFF
--- a/src/components/ui/forms/input/EmailTextInputField.tsx
+++ b/src/components/ui/forms/input/EmailTextInputField.tsx
@@ -34,7 +34,10 @@ export const EmailTextInputField = <TName extends string>({
       ...rules,
       validate: {
         ...rules?.validate,
-        validateEmail: (value: string) => validateEmail(value),
+        validateEmail: (value: string) =>
+          props.required || (value.length > 0 && !props.disabled)
+            ? validateEmail(value)
+            : true,
       },
     }}
     testID={testID}

--- a/src/modules/boat-charging/Stack.tsx
+++ b/src/modules/boat-charging/Stack.tsx
@@ -1,6 +1,7 @@
 import {createStackNavigator} from '@/app/navigation/createStackNavigator'
 import {RootStackParams} from '@/app/navigation/types'
 import {useScreenOptions} from '@/app/navigation/useScreenOptions'
+import {NewSessionFormProvider} from '@/modules/boat-charging/providers/NewSessionForm.provider'
 import {BoatChargingRouteName} from '@/modules/boat-charging/routes'
 import {screenConfig} from '@/modules/boat-charging/screenConfig'
 
@@ -15,6 +16,7 @@ export const ModuleStack = () => {
   return (
     <Stack.Navigator
       initialRouteName={BoatChargingRouteName.map}
+      layout={NewSessionFormProvider}
       screenOptions={screenOptions}>
       {Object.entries(screenConfig).map(([key, route]) => (
         <Stack.Screen

--- a/src/modules/boat-charging/components/BoatChargingDetails.tsx
+++ b/src/modules/boat-charging/components/BoatChargingDetails.tsx
@@ -1,6 +1,5 @@
 import {skipToken} from '@reduxjs/toolkit/query'
 import {useMemo} from 'react'
-import {FormProvider, useForm} from 'react-hook-form'
 import {PleaseWait} from '@/components/ui/feedback/PleaseWait'
 import {SomethingWentWrong} from '@/components/ui/feedback/SomethingWentWrong'
 import {ErrorMessage} from '@/components/ui/forms/ErrorMessage'
@@ -15,12 +14,11 @@ import {BoatChargingDetailsSocketRadioGroup} from '@/modules/boat-charging/compo
 import {BoatChargingDetailsSocketSubmitButton} from '@/modules/boat-charging/components/BoatChargingDetailsSocketSubmitButton'
 import {BoatChargingHelpNavigationButton} from '@/modules/boat-charging/components/navigation/BoatChargingHelpNavigationButton'
 import {useBoatChargingSessions} from '@/modules/boat-charging/hooks/useBoatChargingSessions'
+import {useNewSessionFormContext} from '@/modules/boat-charging/hooks/useNewSessionForm'
 import {useBoatChargingLocationDetailsQuery} from '@/modules/boat-charging/service'
-import {useNewSessionFormValues} from '@/modules/boat-charging/slice'
 import {
   ChargingPointStatus,
   type BoatChargingLocation,
-  type BoatChargingSelectSocketFormValues,
 } from '@/modules/boat-charging/types'
 import {formatMaxKW} from '@/modules/boat-charging/utils/formatMaxKW'
 import {formatTimeToDisplay} from '@/utils/datetime/formatTimeToDisplay'
@@ -43,15 +41,7 @@ export const BoatChargingDetails = ({id}: {id: BoatChargingLocation['id']}) => {
     isError: isErrorSessions,
   } = useBoatChargingSessions()
 
-  const {selectedChargingSocket} = useNewSessionFormValues()
-
   useInterval(refetchLocationDetails, REFETCH_INTERVAL)
-
-  const form = useForm<BoatChargingSelectSocketFormValues>({
-    defaultValues: {
-      selectedSocket: selectedChargingSocket,
-    },
-  })
 
   const infoRows = useMemo(
     () =>
@@ -76,6 +66,8 @@ export const BoatChargingDetails = ({id}: {id: BoatChargingLocation['id']}) => {
     [activeSessions, location],
   )
 
+  const form = useNewSessionFormContext()
+
   if (isLoadingLocation || isLoadingSessions) {
     return <PleaseWait testID="BoatChargingDetailsPleaseWait" />
   }
@@ -98,44 +90,42 @@ export const BoatChargingDetails = ({id}: {id: BoatChargingLocation['id']}) => {
         <BoatChargingDetailsInfoRows rows={infoRows} />
       </Column>
 
-      <FormProvider {...form}>
-        <Column gutter="md">
-          <Column gutter="smd">
-            <Title
-              level="h4"
-              testID="BoatChargingDetailsChooseSocketTitle"
-              text="Kies stopcontact en betaal"
+      <Column gutter="md">
+        <Column gutter="smd">
+          <Title
+            level="h4"
+            testID="BoatChargingDetailsChooseSocketTitle"
+            text="Kies stopcontact en betaal"
+          />
+
+          <Paragraph>
+            Betaal eerst en doe daarna de stekker in het stopcontact.
+          </Paragraph>
+
+          <BoatChargingDetailsSocketRadioGroup
+            chargingStations={location.charging_stations}
+            hasActiveSession={!!activeSessions?.length}
+          />
+          {!!form.formState.errors.root?.message && (
+            <ErrorMessage
+              testID={`BoatChargingDetailsChooseSocketErrorMessage`}
+              text={form.formState.errors.root.message}
             />
+          )}
 
-            <Paragraph>
-              Betaal eerst en doe daarna de stekker in het stopcontact.
-            </Paragraph>
-
-            <BoatChargingDetailsSocketRadioGroup
-              chargingStations={location.charging_stations}
-              hasActiveSession={!!activeSessions?.length}
-            />
-            {!!form.formState.errors.root?.message && (
-              <ErrorMessage
-                testID={`BoatChargingDetailsChooseSocketErrorMessage`}
-                text={form.formState.errors.root.message}
-              />
-            )}
-
-            {!!fulfilledTimeStamp && (
-              <Phrase color="secondary">
-                Laatste update om{' '}
-                {formatTimeToDisplay(fulfilledTimeStamp, {
-                  includeHoursLabel: true,
-                })}
-              </Phrase>
-            )}
-          </Column>
-          <BoatChargingHelpNavigationButton />
+          {!!fulfilledTimeStamp && (
+            <Phrase color="secondary">
+              Laatste update om{' '}
+              {formatTimeToDisplay(fulfilledTimeStamp, {
+                includeHoursLabel: true,
+              })}
+            </Phrase>
+          )}
         </Column>
+        <BoatChargingHelpNavigationButton />
+      </Column>
 
-        {!!showSubmitButton && <BoatChargingDetailsSocketSubmitButton />}
-      </FormProvider>
+      {!!showSubmitButton && <BoatChargingDetailsSocketSubmitButton />}
     </Column>
   )
 }

--- a/src/modules/boat-charging/components/BoatChargingDetailsSocketSubmitButton.tsx
+++ b/src/modules/boat-charging/components/BoatChargingDetailsSocketSubmitButton.tsx
@@ -1,39 +1,36 @@
 import {useCallback} from 'react'
 import {useFormContext} from 'react-hook-form'
-import type {BoatChargingSelectSocketFormValues} from '@/modules/boat-charging/types'
+import type {
+  BoatChargingSelectSocketFormValues,
+  NewSessionFormValues,
+} from '@/modules/boat-charging/types'
 import {Button} from '@/components/ui/buttons/Button'
-import {useInitSession} from '@/modules/boat-charging/hooks/useInitSession'
+import {
+  BoatChargingInitSessionStep,
+  useInitSession,
+} from '@/modules/boat-charging/hooks/useInitSession'
 import {useIsLoggedIn} from '@/modules/boat-charging/hooks/useIsLoggedIn'
-import {useNewSessionFormValues} from '@/modules/boat-charging/slice'
 
 export const BoatChargingDetailsSocketSubmitButton = () => {
   const form = useFormContext<BoatChargingSelectSocketFormValues>()
   const {isLoggedIn} = useIsLoggedIn()
-  const {setSelectedChargingSocket} = useNewSessionFormValues()
 
   const {onPress, isLoading, isError, disabled, mustApproveTerms, refetch} =
-    useInitSession()
+    useInitSession(BoatChargingInitSessionStep.selectSocket)
 
   const onSubmit = useCallback(
-    ({
-      selectedSocket,
-    }: {
-      selectedSocket?: {
-        socketNumber: string
-        stationId: string
-      }
-    }) => {
+    (params: NewSessionFormValues) => {
+      const {selectedSocket} = params
+
       if (!selectedSocket) {
         form.setError('root', {message: 'Kies een stopcontact uit de lijst.'})
 
         return Promise.resolve()
       }
 
-      setSelectedChargingSocket(selectedSocket)
-
-      return onPress()
+      return onPress(params)
     },
-    [setSelectedChargingSocket, onPress, form],
+    [onPress, form],
   )
 
   if (isLoggedIn && !mustApproveTerms) {

--- a/src/modules/boat-charging/components/BoatChargingGuestEmailForm.tsx
+++ b/src/modules/boat-charging/components/BoatChargingGuestEmailForm.tsx
@@ -10,6 +10,7 @@ import {
   BoatChargingInitSessionStep,
   useInitSession,
 } from '@/modules/boat-charging/hooks/useInitSession'
+import {useIsLoggedIn} from '@/modules/boat-charging/hooks/useIsLoggedIn'
 import {BoatChargingRouteName} from '@/modules/boat-charging/routes'
 import {RedirectKey} from '@/modules/redirects/types'
 
@@ -25,6 +26,7 @@ export const BoatChargingGuestEmailForm = () => {
     (params: NewSessionFormValues) => onPress(params),
     [onPress],
   )
+  const {isLoggedIn} = useIsLoggedIn()
 
   return (
     <Column gutter="xl">
@@ -35,9 +37,10 @@ export const BoatChargingGuestEmailForm = () => {
 
         <EmailTextInputField<'email'>
           autoFocus
+          disabled={isLoggedIn}
           name="email"
           onSubmitEditing={handleSubmit(onSubmit)}
-          required
+          required={!isLoggedIn}
           testID="BoatChargingGuestEmailTextInputField"
         />
       </Column>
@@ -50,7 +53,11 @@ export const BoatChargingGuestEmailForm = () => {
         />
         <Button
           label="Inloggen"
-          onPress={() => navigate(BoatChargingRouteName.login)}
+          onPress={() =>
+            navigate(BoatChargingRouteName.login, {
+              afterLoginRoute: [BoatChargingRouteName.termsAndConditions],
+            })
+          }
           testID="BoatChargingGuestEmailFormLoginButton"
           variant="secondary"
         />

--- a/src/modules/boat-charging/components/BoatChargingGuestEmailForm.tsx
+++ b/src/modules/boat-charging/components/BoatChargingGuestEmailForm.tsx
@@ -1,75 +1,66 @@
-import {useCallback, useRef} from 'react'
-import {FormProvider, useForm} from 'react-hook-form'
-import type {TextInput as TextInputRN} from 'react-native-gesture-handler'
+import {useCallback} from 'react'
+import type {NewSessionFormValues} from '@/modules/boat-charging/types'
 import {Button} from '@/components/ui/buttons/Button'
 import {ExternalLinkButton} from '@/components/ui/buttons/ExternalLinkButton'
 import {EmailTextInputField} from '@/components/ui/forms/input/EmailTextInputField'
 import {Column} from '@/components/ui/layout/Column'
 import {Paragraph} from '@/components/ui/text/Paragraph'
 import {useNavigation} from '@/hooks/navigation/useNavigation'
-import {useFocusAndForegroundEffect} from '@/hooks/useFocusAndForegroundEffect'
-import {useInitSession} from '@/modules/boat-charging/hooks/useInitSession'
+import {
+  BoatChargingInitSessionStep,
+  useInitSession,
+} from '@/modules/boat-charging/hooks/useInitSession'
 import {BoatChargingRouteName} from '@/modules/boat-charging/routes'
-import {useNewSessionFormValues} from '@/modules/boat-charging/slice'
 import {RedirectKey} from '@/modules/redirects/types'
 
 export const BoatChargingGuestEmailForm = () => {
-  const emailRef = useRef<TextInputRN>(null)
-  const {setGuestEmail, email: guestEmail} = useNewSessionFormValues()
-  const form = useForm<{email: string}>({defaultValues: {email: guestEmail}})
-
   const {navigate} = useNavigation()
 
-  const {onPress} = useInitSession()
+  const {
+    onPress,
+    form: {handleSubmit},
+  } = useInitSession(BoatChargingInitSessionStep.guestEmail)
 
   const onSubmit = useCallback(
-    ({email}: {email: string}) => {
-      setGuestEmail(email)
-
-      return onPress()
-    },
-    [onPress, setGuestEmail],
+    (params: NewSessionFormValues) => onPress(params),
+    [onPress],
   )
 
-  useFocusAndForegroundEffect(() => emailRef.current?.focus(), [])
-
   return (
-    <FormProvider {...form}>
-      <Column gutter="xl">
-        <Column gutter="lg">
-          <Paragraph>
-            U ontvangt een link naar uw laadsessie en het betaalbewijs.
-          </Paragraph>
+    <Column gutter="xl">
+      <Column gutter="lg">
+        <Paragraph>
+          U ontvangt een link naar uw laadsessie en het betaalbewijs.
+        </Paragraph>
 
-          <EmailTextInputField<'email'>
-            name="email"
-            onSubmitEditing={form.handleSubmit(onSubmit)}
-            ref={emailRef}
-            required
-            testID="BoatChargingGuestEmailTextInputField"
-          />
-        </Column>
-
-        <Column gutter="lg">
-          <Button
-            label="Verder met opladen"
-            onPress={form.handleSubmit(onSubmit)}
-            testID="BoatChargingGuestEmailFormSubmitButton"
-          />
-          <Button
-            label="Inloggen"
-            onPress={() => navigate(BoatChargingRouteName.login)}
-            testID="BoatChargingGuestEmailFormLoginButton"
-            variant="secondary"
-          />
-          <ExternalLinkButton
-            label="Account aanmaken"
-            redirectKey={RedirectKey.boatChargingCreateAccount}
-            testID="BoatChargingGuestEmailFormCreateAccountButton"
-            variant="tertiary"
-          />
-        </Column>
+        <EmailTextInputField<'email'>
+          autoFocus
+          name="email"
+          onSubmitEditing={handleSubmit(onSubmit)}
+          required
+          testID="BoatChargingGuestEmailTextInputField"
+        />
       </Column>
-    </FormProvider>
+
+      <Column gutter="lg">
+        <Button
+          label="Verder met opladen"
+          onPress={handleSubmit(onSubmit)}
+          testID="BoatChargingGuestEmailFormSubmitButton"
+        />
+        <Button
+          label="Inloggen"
+          onPress={() => navigate(BoatChargingRouteName.login)}
+          testID="BoatChargingGuestEmailFormLoginButton"
+          variant="secondary"
+        />
+        <ExternalLinkButton
+          label="Account aanmaken"
+          redirectKey={RedirectKey.boatChargingCreateAccount}
+          testID="BoatChargingGuestEmailFormCreateAccountButton"
+          variant="tertiary"
+        />
+      </Column>
+    </Column>
   )
 }

--- a/src/modules/boat-charging/components/BoatChargingHistorySessionDetails.tsx
+++ b/src/modules/boat-charging/components/BoatChargingHistorySessionDetails.tsx
@@ -39,7 +39,10 @@ export const BoatChargingHistorySessionDetails = () => {
 
   const {setAlert} = useAlert()
 
-  const completedSessionSeenIds = useSelector(selectCompletedSessionSeenIds)
+  const completedSessionSeenIds = useSelector(
+    selectCompletedSessionSeenIds,
+    (a, b) => a.length === b.length,
+  )
 
   useEffect(() => {
     if (session && !completedSessionSeenIds.includes(session?.id)) {

--- a/src/modules/boat-charging/components/BoatChargingLoginForm.tsx
+++ b/src/modules/boat-charging/components/BoatChargingLoginForm.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useRef, useState} from 'react'
 import {FormProvider, useForm, type SubmitHandler} from 'react-hook-form'
+import type {BoatChargingRouteName} from '@/modules/boat-charging/routes'
 import type {TextInput as TextInputRN} from 'react-native-gesture-handler'
 import {Button} from '@/components/ui/buttons/Button'
 import {ExternalLinkButton} from '@/components/ui/buttons/ExternalLinkButton'
@@ -10,6 +11,7 @@ import {FieldType} from '@/components/ui/forms/input/types'
 import {Column} from '@/components/ui/layout/Column'
 import {Paragraph} from '@/components/ui/text/Paragraph'
 import {useNavigation} from '@/hooks/navigation/useNavigation'
+import {useRoute} from '@/hooks/navigation/useRoute'
 import {useOpenIdConnectAuth} from '@/modules/boat-charging/hooks/useOpenIdConnectAuth'
 import {RedirectKey} from '@/modules/redirects/types'
 
@@ -23,7 +25,12 @@ export const BoatChargingLoginForm = () => {
   const form = useForm<FormValues>()
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const passwordInputReference = useRef<TextInputRN>(null)
-  const {canGoBack, goBack} = useNavigation()
+  const navigation = useNavigation()
+  const {canGoBack, goBack} = navigation
+
+  const {params} = useRoute<BoatChargingRouteName.login>()
+
+  const afterLoginRoute = params?.afterLoginRoute
 
   const handleSignIn: SubmitHandler<FormValues> = useCallback(
     async ({username, password}) => {
@@ -38,7 +45,10 @@ export const BoatChargingLoginForm = () => {
       try {
         await signIn(username, password)
 
-        if (canGoBack()) {
+        if (afterLoginRoute) {
+          // @ts-expect-error: afterLoginRoute is a tuple of route name and params, so we can spread it into navigate
+          navigation.replace(...afterLoginRoute)
+        } else if (canGoBack()) {
           goBack()
         }
       } catch (error) {
@@ -47,7 +57,7 @@ export const BoatChargingLoginForm = () => {
         )
       }
     },
-    [canGoBack, goBack, signIn],
+    [afterLoginRoute, canGoBack, goBack, navigation, signIn],
   )
 
   return (

--- a/src/modules/boat-charging/components/bottomsheet/BoatChargingPointDetails.tsx
+++ b/src/modules/boat-charging/components/bottomsheet/BoatChargingPointDetails.tsx
@@ -17,6 +17,7 @@ import {BoatChargingPointDetailsButton} from '@/modules/boat-charging/components
 import {boatChargingPointStateMap} from '@/modules/boat-charging/constants/boatChargingPointStateMap'
 import {mapStatusToState} from '@/modules/boat-charging/constants/mapStatusToState'
 import {useAvailableAndOtherEvses} from '@/modules/boat-charging/hooks/useAvailableAndOtherEvses'
+import {useNewSessionFormContext} from '@/modules/boat-charging/hooks/useNewSessionForm'
 import {BoatChargingRouteName} from '@/modules/boat-charging/routes'
 import {useBoatChargingLocationDetailsQuery} from '@/modules/boat-charging/service'
 import {
@@ -64,6 +65,7 @@ export const BoatChargingPointDetails = () => {
   const {availableEvses, evses} = useAvailableAndOtherEvses(
     location?.charging_stations ?? [],
   )
+  const {reset} = useNewSessionFormContext()
 
   if (isLoading) {
     return <PleaseWait testID="BoatChargingPointDetailsPleaseWait" />
@@ -114,9 +116,11 @@ export const BoatChargingPointDetails = () => {
         </Column>
         {!!id && (
           <BoatChargingPointDetailsButton
-            onPress={() =>
-              navigate(BoatChargingRouteName.locationDetails, {id})
-            }
+            onPress={() => {
+              reset()
+
+              return navigate(BoatChargingRouteName.locationDetails, {id})
+            }}
             status={status}
           />
         )}

--- a/src/modules/boat-charging/hooks/useInitSession.ts
+++ b/src/modules/boat-charging/hooks/useInitSession.ts
@@ -46,11 +46,8 @@ export const useInitSession = (step: BoatChargingInitSessionStep) => {
     (params: NewSessionFormValues) => {
       const state = store.getState()
       let email = params.email
-      const {
-        selectedSocket: {socketNumber, stationId},
-        approvedTerms,
-        didVerifyEmail,
-      } = params
+      const {selectedSocket, approvedTerms, didVerifyEmail} = params
+      const {socketNumber, stationId} = selectedSocket || {}
       const lastApprovedTermsVersionFromState =
         selectLastApprovedTermsVersionWhileLoggedIn(state)
 

--- a/src/modules/boat-charging/hooks/useInitSession.ts
+++ b/src/modules/boat-charging/hooks/useInitSession.ts
@@ -1,9 +1,11 @@
 import {useCallback} from 'react'
+import type {NewSessionFormValues} from '@/modules/boat-charging/types'
 import {useOpenWebUrl} from '@/hooks/linking/useOpenWebUrl'
 import {useNavigation} from '@/hooks/navigation/useNavigation'
 import {useSelector} from '@/hooks/redux/useSelector'
 import {useStore} from '@/hooks/redux/useStore'
 import {useIsLoggedIn} from '@/modules/boat-charging/hooks/useIsLoggedIn'
+import {useNewSessionFormContext} from '@/modules/boat-charging/hooks/useNewSessionForm'
 import {BoatChargingRouteName} from '@/modules/boat-charging/routes'
 import {
   useBoatChargingTermsQuery,
@@ -13,8 +15,18 @@ import {
   selectBoatChargingLoggedInUsername,
   selectLastApprovedTermsVersionWhileLoggedIn,
 } from '@/modules/boat-charging/slice'
+import {validateEmail} from '@/utils/validate'
 
-export const useInitSession = () => {
+export enum BoatChargingInitSessionStep {
+  guestEmail = 2,
+  guestEmailConfirm = 3,
+  selectSocket = 1,
+  termsAndConditions = 4,
+}
+
+export const useInitSession = (step: BoatChargingInitSessionStep) => {
+  const form = useNewSessionFormContext()
+
   const {data: terms, isLoading, isError, refetch} = useBoatChargingTermsQuery()
   const [
     initSession,
@@ -30,73 +42,90 @@ export const useInitSession = () => {
   const openWebUrl = useOpenWebUrl()
   const store = useStore()
 
-  const onPress = useCallback(() => {
-    const state = store.getState()
-    let {email} = state.boatCharging.newSessionFormValues || {}
-    const {socketNumber, stationId, approvedTerms, didVerifyEmail} =
-      state.boatCharging.newSessionFormValues || {}
-    const lastApprovedTermsVersionFromState =
-      selectLastApprovedTermsVersionWhileLoggedIn(state)
+  const onPress = useCallback(
+    (params: NewSessionFormValues) => {
+      const state = store.getState()
+      let email = params.email
+      const {
+        selectedSocket: {socketNumber, stationId},
+        approvedTerms,
+        didVerifyEmail,
+      } = params
+      const lastApprovedTermsVersionFromState =
+        selectLastApprovedTermsVersionWhileLoggedIn(state)
 
-    if (!socketNumber || !stationId) {
-      navigation.replace(BoatChargingRouteName.map)
-
-      return Promise.resolve()
-    }
-
-    if (isLoggedIn) {
-      if (!loggedInUsername) {
-        return Promise.resolve()
-      }
-
-      email = loggedInUsername
-
-      if (terms?.version !== lastApprovedTermsVersionFromState) {
-        navigate(BoatChargingRouteName.termsAndConditions)
-
-        return Promise.resolve()
-      }
-    } else {
-      if (!email) {
-        navigate(BoatChargingRouteName.guestEmail)
+      if (!socketNumber || !stationId) {
+        navigation.replace(BoatChargingRouteName.map)
 
         return Promise.resolve()
       }
 
-      if (!didVerifyEmail) {
-        navigate(BoatChargingRouteName.guestEmailConfirm)
+      if (isLoggedIn) {
+        if (!loggedInUsername) {
+          return Promise.resolve()
+        }
 
-        return Promise.resolve()
+        email = loggedInUsername
+
+        if (terms?.version !== lastApprovedTermsVersionFromState) {
+          navigate(BoatChargingRouteName.termsAndConditions)
+
+          return Promise.resolve()
+        }
+      } else {
+        if (
+          !email ||
+          validateEmail(email) !== true ||
+          step === BoatChargingInitSessionStep.selectSocket
+        ) {
+          navigate(BoatChargingRouteName.guestEmail)
+
+          return Promise.resolve()
+        }
+
+        if (
+          !didVerifyEmail ||
+          step === BoatChargingInitSessionStep.guestEmail
+        ) {
+          navigate(BoatChargingRouteName.guestEmailConfirm)
+
+          return Promise.resolve()
+        }
+
+        if (
+          !approvedTerms ||
+          step === BoatChargingInitSessionStep.guestEmailConfirm
+        ) {
+          navigate(BoatChargingRouteName.termsAndConditions)
+
+          return Promise.resolve()
+        }
       }
 
-      if (!approvedTerms) {
-        navigate(BoatChargingRouteName.termsAndConditions)
-
-        return Promise.resolve()
-      }
-    }
-
-    return initSession({
-      station_id: stationId,
-      socket_number: socketNumber,
-      email,
-      name: email,
-      return_url: 'amsterdam://boat-charging/payment',
-    })
-      .unwrap()
-      .then(({checkout_url}) => {
-        openWebUrl(checkout_url)
+      return initSession({
+        station_id: stationId,
+        socket_number: socketNumber,
+        email,
+        name: email,
+        return_url: 'amsterdam://boat-charging/payment',
       })
-  }, [
-    initSession,
-    isLoggedIn,
-    loggedInUsername,
-    navigate,
-    navigation,
-    openWebUrl,
-    store,
-    terms?.version,
-  ])
+        .unwrap()
+        .then(({checkout_url}) => {
+          openWebUrl(checkout_url)
+        })
+    },
+    [
+      initSession,
+      isLoggedIn,
+      loggedInUsername,
+      navigate,
+      navigation,
+      openWebUrl,
+      step,
+      store,
+      terms?.version,
+    ],
+  )
 
   return {
     onPress,
@@ -106,5 +135,6 @@ export const useInitSession = () => {
     isLoading: isLoading || isInitSessionLoading,
     isError: isError || isInitSessionError,
     refetch,
+    form,
   }
 }

--- a/src/modules/boat-charging/hooks/useNewSessionForm.ts
+++ b/src/modules/boat-charging/hooks/useNewSessionForm.ts
@@ -1,0 +1,11 @@
+import {useForm, useFormContext} from 'react-hook-form'
+import type {NewSessionFormValues} from '@/modules/boat-charging/types'
+
+export const useNewSessionForm = () =>
+  useForm<NewSessionFormValues>({
+    reValidateMode: 'onSubmit',
+    mode: 'onSubmit',
+  })
+
+export const useNewSessionFormContext = () =>
+  useFormContext<NewSessionFormValues>()

--- a/src/modules/boat-charging/hooks/useRedirectAfterPayment.ts
+++ b/src/modules/boat-charging/hooks/useRedirectAfterPayment.ts
@@ -4,6 +4,7 @@ import {useNavigation} from '@/hooks/navigation/useNavigation'
 import {useDispatch} from '@/hooks/redux/useDispatch'
 import {alerts} from '@/modules/boat-charging/alerts'
 import {useIsLoggedIn} from '@/modules/boat-charging/hooks/useIsLoggedIn'
+import {useNewSessionFormContext} from '@/modules/boat-charging/hooks/useNewSessionForm'
 import {BoatChargingRouteName} from '@/modules/boat-charging/routes'
 import {setLastGuestSessionId} from '@/modules/boat-charging/slice'
 import {useAlert} from '@/store/slices/alert'
@@ -13,6 +14,7 @@ export const useRedirectAfterPayment = () => {
   const dispatch = useDispatch()
   const {isLoggedIn} = useIsLoggedIn()
   const {setAlert} = useAlert()
+  const {reset} = useNewSessionFormContext()
 
   return useCallback(
     (paymentStatus: BoatChargingPaymentResultStatus, sessionId: string) => {
@@ -20,6 +22,8 @@ export const useRedirectAfterPayment = () => {
         if (!isLoggedIn) {
           dispatch(setLastGuestSessionId(sessionId))
         }
+
+        reset()
 
         navigation.popTo(BoatChargingRouteName.map)
         navigation.push(BoatChargingRouteName.activeSessionDetails, {
@@ -30,6 +34,6 @@ export const useRedirectAfterPayment = () => {
         setAlert(alerts.paymentFailed)
       }
     },
-    [isLoggedIn, dispatch, navigation, setAlert],
+    [isLoggedIn, reset, navigation, dispatch, setAlert],
   )
 }

--- a/src/modules/boat-charging/providers/NewSessionForm.provider.tsx
+++ b/src/modules/boat-charging/providers/NewSessionForm.provider.tsx
@@ -1,0 +1,9 @@
+import {FormProvider} from 'react-hook-form'
+import type {PropsWithChildren} from 'react'
+import {useNewSessionForm} from '@/modules/boat-charging/hooks/useNewSessionForm'
+
+export const NewSessionFormProvider = ({children}: PropsWithChildren) => {
+  const form = useNewSessionForm()
+
+  return <FormProvider {...form}>{children}</FormProvider>
+}

--- a/src/modules/boat-charging/routes.ts
+++ b/src/modules/boat-charging/routes.ts
@@ -1,8 +1,9 @@
+import type {InStackTo} from '@/app/navigation/types'
 import type {
   BoatChargingLocation,
   BoatChargingSession,
+  BoatChargingPaymentResultStatus,
 } from '@/modules/boat-charging/types'
-import type {BoatChargingPaymentResultStatus} from '@/modules/boat-charging/types'
 
 export enum BoatChargingRouteName {
   activeSessionDetails = 'BoatChargingActiveSessionDetails',
@@ -27,7 +28,11 @@ export type ModuleStackParams = {
   [BoatChargingRouteName.guestEmailConfirm]: undefined
   [BoatChargingRouteName.help]: undefined
   [BoatChargingRouteName.history]: undefined
-  [BoatChargingRouteName.login]: undefined
+  [BoatChargingRouteName.login]:
+    | {
+        afterLoginRoute?: InStackTo
+      }
+    | undefined
   [BoatChargingRouteName.activeSessionDetails]: {
     id: BoatChargingSession['id']
   }

--- a/src/modules/boat-charging/screens/BoatChargingGuestEmailConfirm.screen.tsx
+++ b/src/modules/boat-charging/screens/BoatChargingGuestEmailConfirm.screen.tsx
@@ -1,4 +1,3 @@
-import {useCallback} from 'react'
 import {Screen} from '@/components/features/screen/Screen'
 import {Button} from '@/components/ui/buttons/Button'
 import {NavigationButton} from '@/components/ui/buttons/NavigationButton'
@@ -8,20 +7,20 @@ import {Column} from '@/components/ui/layout/Column'
 import {Paragraph} from '@/components/ui/text/Paragraph'
 import {Title} from '@/components/ui/text/Title'
 import {useNavigation} from '@/hooks/navigation/useNavigation'
-import {useInitSession} from '@/modules/boat-charging/hooks/useInitSession'
-import {useNewSessionFormValues} from '@/modules/boat-charging/slice'
+import {
+  BoatChargingInitSessionStep,
+  useInitSession,
+} from '@/modules/boat-charging/hooks/useInitSession'
 
 export const BoatChargingGuestEmailConfirmScreen = () => {
   const navigation = useNavigation()
-  const {email, setDidVerifyEmail} = useNewSessionFormValues()
 
-  const {onPress} = useInitSession()
+  const {
+    onPress,
+    form: {handleSubmit, watch, setValue},
+  } = useInitSession(BoatChargingInitSessionStep.guestEmailConfirm)
 
-  const onButtonPress = useCallback(() => {
-    setDidVerifyEmail(true)
-
-    return onPress()
-  }, [onPress, setDidVerifyEmail])
+  const email = watch('email')
 
   if (!email) {
     return (
@@ -47,7 +46,7 @@ export const BoatChargingGuestEmailConfirmScreen = () => {
               emphasis="default"
               horizontallyAlign="center"
               onPress={() => {
-                setDidVerifyEmail(false)
+                setValue('didVerifyEmail', false)
                 navigation.goBack()
               }}
               testID="BoatChargingGuestEmailConfirmScreenChangeEmailAddressButton"
@@ -59,7 +58,11 @@ export const BoatChargingGuestEmailConfirmScreen = () => {
         <Button
           label="Ja, dit klopt"
           marginTop="auto"
-          onPress={onButtonPress}
+          onPress={e => {
+            setValue('didVerifyEmail', true)
+
+            return handleSubmit(onPress)(e)
+          }}
           testID="BoatChargingGuestEmailConfirmSubmitButton"
         />
       </Box>

--- a/src/modules/boat-charging/screens/BoatChargingLogin.screen.tsx
+++ b/src/modules/boat-charging/screens/BoatChargingLogin.screen.tsx
@@ -2,7 +2,6 @@ import {Screen} from '@/components/features/screen/Screen'
 import {Button} from '@/components/ui/buttons/Button'
 import {Box} from '@/components/ui/containers/Box'
 import {Column} from '@/components/ui/layout/Column'
-import {Phrase} from '@/components/ui/text/Phrase'
 import {BoatChargingLoginForm} from '@/modules/boat-charging/components/BoatChargingLoginForm'
 import {useOpenIdConnectAuth} from '@/modules/boat-charging/hooks/useOpenIdConnectAuth'
 
@@ -17,7 +16,6 @@ export const BoatChargingLoginScreen = () => {
       {isLoggedIn ? (
         <Box>
           <Column>
-            <Phrase>Al ingelogd</Phrase>
             <Button
               label="Uitloggen"
               onPress={signOut}

--- a/src/modules/boat-charging/screens/BoatChargingTermsAndConditions.screen.tsx
+++ b/src/modules/boat-charging/screens/BoatChargingTermsAndConditions.screen.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect} from 'react'
+import {useCallback} from 'react'
 import type {NavigationProps} from '@/app/navigation/types'
 import type {NewSessionFormValues} from '@/modules/boat-charging/types'
 import {Screen} from '@/components/features/screen/Screen'
@@ -13,7 +13,6 @@ import {HtmlContent} from '@/components/ui/text/HtmlContent'
 import {Phrase} from '@/components/ui/text/Phrase'
 import {Title} from '@/components/ui/text/Title'
 import {useDispatch} from '@/hooks/redux/useDispatch'
-import {useSelector} from '@/hooks/redux/useSelector'
 import {
   BoatChargingInitSessionStep,
   useInitSession,
@@ -21,10 +20,7 @@ import {
 import {useIsLoggedIn} from '@/modules/boat-charging/hooks/useIsLoggedIn'
 import {BoatChargingRouteName} from '@/modules/boat-charging/routes'
 import {useBoatChargingTermsQuery} from '@/modules/boat-charging/service'
-import {
-  selectLastApprovedTermsVersionWhileLoggedIn,
-  setLastApprovedTermsVersionWhileLoggedIn,
-} from '@/modules/boat-charging/slice'
+import {setLastApprovedTermsVersionWhileLoggedIn} from '@/modules/boat-charging/slice'
 import {RedirectKey} from '@/modules/redirects/types'
 
 type Props = NavigationProps<BoatChargingRouteName.termsAndConditions>
@@ -35,24 +31,12 @@ const AGREED_TO_TERMS_ERROR_MESSAGE =
 export const BoatChargingTermsAndConditionsScreen = ({}: Props) => {
   const {
     onPress,
-    form: {handleSubmit, setError, setValue, watch},
+    form: {handleSubmit, setError, watch},
   } = useInitSession(BoatChargingInitSessionStep.termsAndConditions)
 
   const {data: terms, isLoading, isError, refetch} = useBoatChargingTermsQuery()
-  const lastApprovedTermsVersion = useSelector(
-    selectLastApprovedTermsVersionWhileLoggedIn,
-  )
   const dispatch = useDispatch()
   const {isLoggedIn} = useIsLoggedIn()
-
-  const alreadyAgreedToTerms =
-    isLoggedIn && terms?.version === lastApprovedTermsVersion
-
-  useEffect(() => {
-    if (alreadyAgreedToTerms) {
-      setValue('approvedTerms', true)
-    }
-  }, [alreadyAgreedToTerms, setValue])
   const agreedToTerms = watch('approvedTerms')
 
   const onSubmit = useCallback(

--- a/src/modules/boat-charging/screens/BoatChargingTermsAndConditions.screen.tsx
+++ b/src/modules/boat-charging/screens/BoatChargingTermsAndConditions.screen.tsx
@@ -1,6 +1,6 @@
-import {useEffect} from 'react'
-import {useForm, FormProvider} from 'react-hook-form'
+import {useCallback, useEffect} from 'react'
 import type {NavigationProps} from '@/app/navigation/types'
+import type {NewSessionFormValues} from '@/modules/boat-charging/types'
 import {Screen} from '@/components/features/screen/Screen'
 import {Button} from '@/components/ui/buttons/Button'
 import {Box} from '@/components/ui/containers/Box'
@@ -14,33 +14,29 @@ import {Phrase} from '@/components/ui/text/Phrase'
 import {Title} from '@/components/ui/text/Title'
 import {useDispatch} from '@/hooks/redux/useDispatch'
 import {useSelector} from '@/hooks/redux/useSelector'
-import {useInitSession} from '@/modules/boat-charging/hooks/useInitSession'
+import {
+  BoatChargingInitSessionStep,
+  useInitSession,
+} from '@/modules/boat-charging/hooks/useInitSession'
 import {useIsLoggedIn} from '@/modules/boat-charging/hooks/useIsLoggedIn'
 import {BoatChargingRouteName} from '@/modules/boat-charging/routes'
 import {useBoatChargingTermsQuery} from '@/modules/boat-charging/service'
 import {
   selectLastApprovedTermsVersionWhileLoggedIn,
   setLastApprovedTermsVersionWhileLoggedIn,
-  useNewSessionFormValues,
 } from '@/modules/boat-charging/slice'
 import {RedirectKey} from '@/modules/redirects/types'
 
 type Props = NavigationProps<BoatChargingRouteName.termsAndConditions>
 
-type FormValues = {
-  agreedToTerms: boolean
-}
-
 const AGREED_TO_TERMS_ERROR_MESSAGE =
   'Ga akkoord gaan met de voorwaarden om verder te gaan.'
 
 export const BoatChargingTermsAndConditionsScreen = ({}: Props) => {
-  const form = useForm<FormValues>({
-    defaultValues: {
-      agreedToTerms: false,
-    },
-  })
-  const {handleSubmit, setError} = form
+  const {
+    onPress,
+    form: {handleSubmit, setError, setValue, watch},
+  } = useInitSession(BoatChargingInitSessionStep.termsAndConditions)
 
   const {data: terms, isLoading, isError, refetch} = useBoatChargingTermsQuery()
   const lastApprovedTermsVersion = useSelector(
@@ -54,87 +50,83 @@ export const BoatChargingTermsAndConditionsScreen = ({}: Props) => {
 
   useEffect(() => {
     if (alreadyAgreedToTerms) {
-      form.setValue('agreedToTerms', true)
+      setValue('approvedTerms', true)
     }
-  }, [alreadyAgreedToTerms, form])
-  const agreedToTerms = form.watch('agreedToTerms')
+  }, [alreadyAgreedToTerms, setValue])
+  const agreedToTerms = watch('approvedTerms')
 
-  const {setApprovedTerms} = useNewSessionFormValues()
-  const {onPress} = useInitSession()
+  const onSubmit = useCallback(
+    (params: NewSessionFormValues) => {
+      if (!params.approvedTerms || !terms) {
+        setError('approvedTerms', {
+          type: 'manual',
+          message: AGREED_TO_TERMS_ERROR_MESSAGE,
+        })
 
-  const onSubmit = () => {
-    if (!terms) {
-      setError('agreedToTerms', {
-        type: 'manual',
-        message: AGREED_TO_TERMS_ERROR_MESSAGE,
-      })
+        return
+      }
 
-      return
-    }
+      if (isLoggedIn) {
+        dispatch(setLastApprovedTermsVersionWhileLoggedIn(terms.version))
+      }
 
-    if (isLoggedIn) {
-      dispatch(setLastApprovedTermsVersionWhileLoggedIn(terms.version))
-    }
-
-    setApprovedTerms(true)
-
-    return onPress()
-  }
+      return onPress(params)
+    },
+    [terms, isLoggedIn, dispatch, onPress, setError],
+  )
 
   return (
-    <FormProvider {...form}>
-      <Screen
-        stickyFooter={
-          <Box>
-            <Button
-              icon={{name: 'boat-charging-free', color: 'inverse'}}
-              isLoading={isLoading}
-              label="Betalen en laden"
-              onPress={isError ? refetch : handleSubmit(onSubmit)}
-              testID="BoatChargingTermsAndConditionsScreenSubmitButton"
-            />
-          </Box>
-        }
-        testID="BoatChargingTermsAndConditionsScreen">
-        <Box grow>
-          <Title
-            level="h4"
-            text="In het kort"
-          />
-          <Gutter height="sm" />
-          {isLoading ? (
-            <PleaseWait testID="BoatChargingTermsAndConditionsPleaseWait" />
-          ) : isError ? (
-            <Box insetVertical="md">
-              <SomethingWentWrong testID="BoatChargingTermsAndConditionsSomethingWentWrong" />
-            </Box>
-          ) : (
-            !!terms && (
-              <HtmlContent
-                content={terms.content}
-                testID="BoatChargingTermsAndConditionsHtmlContent"
-              />
-            )
-          )}
-          <ExternalInlineLink
-            redirectKey={RedirectKey.boatChargingTermsAndConditions}
-            testID="BoatChargingTermsAndConditionsExternalLink">
-            Bekijk alle voorwaarden
-          </ExternalInlineLink>
-
-          <Gutter height="xl" />
-          <SwitchField
-            accessibilityLabel={`Ik ga akkoord met de voorwaarden staat ${agreedToTerms ? 'aan' : 'uit'}`}
-            disabled={isLoading || isError}
-            label={<Phrase>Ik ga akkoord met de voorwaarden</Phrase>}
-            name="agreedToTerms"
-            rules={{
-              required: AGREED_TO_TERMS_ERROR_MESSAGE,
-            }}
-            testID="BoatChargingTermsAndConditionsSwitch"
+    <Screen
+      stickyFooter={
+        <Box>
+          <Button
+            icon={{name: 'boat-charging-free', color: 'inverse'}}
+            isLoading={isLoading}
+            label="Betalen en laden"
+            onPress={isError ? refetch : handleSubmit(onSubmit)}
+            testID="BoatChargingTermsAndConditionsScreenSubmitButton"
           />
         </Box>
-      </Screen>
-    </FormProvider>
+      }
+      testID="BoatChargingTermsAndConditionsScreen">
+      <Box grow>
+        <Title
+          level="h4"
+          text="In het kort"
+        />
+        <Gutter height="sm" />
+        {isLoading ? (
+          <PleaseWait testID="BoatChargingTermsAndConditionsPleaseWait" />
+        ) : isError ? (
+          <Box insetVertical="md">
+            <SomethingWentWrong testID="BoatChargingTermsAndConditionsSomethingWentWrong" />
+          </Box>
+        ) : (
+          !!terms && (
+            <HtmlContent
+              content={terms.content}
+              testID="BoatChargingTermsAndConditionsHtmlContent"
+            />
+          )
+        )}
+        <ExternalInlineLink
+          redirectKey={RedirectKey.boatChargingTermsAndConditions}
+          testID="BoatChargingTermsAndConditionsExternalLink">
+          Bekijk alle voorwaarden
+        </ExternalInlineLink>
+
+        <Gutter height="xl" />
+        <SwitchField
+          accessibilityLabel={`Ik ga akkoord met de voorwaarden staat ${agreedToTerms ? 'aan' : 'uit'}`}
+          disabled={isLoading || isError}
+          label={<Phrase>Ik ga akkoord met de voorwaarden</Phrase>}
+          name="approvedTerms"
+          rules={{
+            required: AGREED_TO_TERMS_ERROR_MESSAGE,
+          }}
+          testID="BoatChargingTermsAndConditionsSwitch"
+        />
+      </Box>
+    </Screen>
   )
 }

--- a/src/modules/boat-charging/slice.ts
+++ b/src/modules/boat-charging/slice.ts
@@ -3,7 +3,6 @@ import {useCallback} from 'react'
 import type {
   BoatChargingLocation,
   BoatChargingOIDCConfigResponse,
-  BoatChargingSelectSocketFormSelectedSocket,
 } from '@/modules/boat-charging/types'
 import type {RootState} from '@/store/types/rootState'
 import {useDispatch} from '@/hooks/redux/useDispatch'
@@ -17,13 +16,6 @@ export type BoatChargingState = {
   lastApprovedTermsVersionWhileLoggedIn?: number
   lastGuestSessionId?: string
   loggedInUsername?: string
-  newSessionFormValues?: {
-    approvedTerms?: boolean
-    didVerifyEmail?: boolean
-    email?: string
-    socketNumber?: string
-    stationId?: string
-  }
   openIdConnectConfig?: BoatChargingOIDCConfigResponse
   selectedBoatChargingPointId?: BoatChargingLocation['id']
 }
@@ -38,7 +30,6 @@ export const boatChargingSlice = createSlice({
       state,
       {payload: id}: PayloadAction<BoatChargingLocation['id']>,
     ) => {
-      state.newSessionFormValues = undefined
       state.selectedBoatChargingPointId = id
     },
     resetSelectedBoatChargingPointId: state => {
@@ -76,48 +67,6 @@ export const boatChargingSlice = createSlice({
       {payload}: PayloadAction<BoatChargingOIDCConfigResponse>,
     ) => {
       state.openIdConnectConfig = payload
-    },
-    setNewSessionEmail: (state, {payload: email}: PayloadAction<string>) => {
-      state.newSessionFormValues = {
-        ...state.newSessionFormValues,
-        email,
-        didVerifyEmail: false,
-        approvedTerms: false,
-      }
-    },
-    setNewSessionDidVerifyEmail: (
-      state,
-      {payload: didVerifyEmail}: PayloadAction<boolean>,
-    ) => {
-      state.newSessionFormValues = {
-        ...state.newSessionFormValues,
-        didVerifyEmail,
-        approvedTerms: false,
-      }
-    },
-    setNewSessionApprovedTerms: (
-      state,
-      {payload: approvedTerms}: PayloadAction<boolean>,
-    ) => {
-      state.newSessionFormValues = {
-        ...state.newSessionFormValues,
-        approvedTerms,
-      }
-    },
-    setNewSessionSelectedChargingSocket: (
-      state,
-      {payload}: PayloadAction<BoatChargingSelectSocketFormSelectedSocket>,
-    ) => {
-      state.newSessionFormValues = {
-        ...state.newSessionFormValues,
-        socketNumber: payload.socketNumber,
-        stationId: payload.stationId,
-        didVerifyEmail: false,
-        approvedTerms: false,
-      }
-    },
-    resetNewSessionFormValues: state => {
-      state.newSessionFormValues = undefined
     },
     setLastApprovedTermsVersionWhileLoggedIn: (
       state,
@@ -195,52 +144,8 @@ export const useSetBoatChargingAccessToken = () => {
   )
 }
 
-export const selectNewSessionFormValues = (state: RootState) =>
-  state[ReduxKey.boatCharging].newSessionFormValues
-
 export const selectLastApprovedTermsVersionWhileLoggedIn = (state: RootState) =>
   state[ReduxKey.boatCharging].lastApprovedTermsVersionWhileLoggedIn
 
 export const selectCompletedSessionSeenIds = (state: RootState) =>
   state[ReduxKey.boatCharging].completedSessionSeenIds ?? []
-
-export const useNewSessionFormValues = () => {
-  const {
-    setNewSessionEmail,
-    setNewSessionSelectedChargingSocket,
-    setNewSessionApprovedTerms,
-    setNewSessionDidVerifyEmail,
-    resetNewSessionFormValues,
-  } = boatChargingSlice.actions
-
-  const dispatch = useDispatch()
-
-  const guestSessionFormValues = useSelector(selectNewSessionFormValues) || {}
-  const selectedChargingSocket =
-    guestSessionFormValues.stationId && guestSessionFormValues.socketNumber
-      ? {
-          stationId: guestSessionFormValues.stationId,
-          socketNumber: guestSessionFormValues.socketNumber,
-        }
-      : undefined
-
-  const setGuestEmail = (email: string) => dispatch(setNewSessionEmail(email))
-  const setSelectedChargingSocket = (
-    payload: BoatChargingSelectSocketFormSelectedSocket,
-  ) => dispatch(setNewSessionSelectedChargingSocket(payload))
-  const setApprovedTerms = (approvedTerms: boolean) =>
-    dispatch(setNewSessionApprovedTerms(approvedTerms))
-  const setDidVerifyEmail = (didVerifyEmail: boolean) =>
-    dispatch(setNewSessionDidVerifyEmail(didVerifyEmail))
-  const resetForm = () => dispatch(resetNewSessionFormValues())
-
-  return {
-    ...guestSessionFormValues,
-    selectedChargingSocket,
-    setGuestEmail,
-    setSelectedChargingSocket,
-    resetForm,
-    setApprovedTerms,
-    setDidVerifyEmail,
-  }
-}

--- a/src/modules/boat-charging/types.ts
+++ b/src/modules/boat-charging/types.ts
@@ -237,3 +237,10 @@ export enum BoatChargingCostBreakdownItemType {
   PARKING_TIME = 'PARKING_TIME',
   TIME = 'TIME',
 }
+
+export type NewSessionFormValues = {
+  approvedTerms?: boolean
+  didVerifyEmail?: boolean
+  email?: string
+  selectedSocket: BoatChargingSelectSocketFormSelectedSocket
+}

--- a/src/modules/boat-charging/types.ts
+++ b/src/modules/boat-charging/types.ts
@@ -242,5 +242,5 @@ export type NewSessionFormValues = {
   approvedTerms?: boolean
   didVerifyEmail?: boolean
   email?: string
-  selectedSocket: BoatChargingSelectSocketFormSelectedSocket
+  selectedSocket?: BoatChargingSelectSocketFormSelectedSocket
 }


### PR DESCRIPTION
# Changes

## Pull request overview

This PR refactors the boat-charging “new session” flow to use a shared `react-hook-form` form state across the module stack (instead of storing intermediate form values in Redux), and adapts the init-session flow to work step-by-step.

**Changes:**
- Introduces a module-level `FormProvider` (`NewSessionFormProvider`) and a shared form hook (`useNewSessionForm` / `useNewSessionFormContext`).
- Refactors guest email, email confirmation, terms acceptance, and socket selection to read/write from the shared RHF form context.
- Removes `newSessionFormValues` and related actions/selectors from the Redux slice; updates `useInitSession` to accept a “step” and drive navigation accordingly.

## Test instructions

## Other notes

GitHub Copilot was used in writing the code
