### PR TITLE
Story/am 437 laadscherm bij lang wachten uitbreiden

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2468,7 +2468,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNBootSplash (7.3.2):
+  - RNBootSplash (7.3.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3292,7 +3292,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 0608099d4870cac8754bdba9b6953db543432438
   GoogleUtilities: 4f2618a4a1e762a1ee134a1e2323bba9843e06da
-  hermes-engine: a9252ff827cfcaf75e540b56e51acbf41bbf6fbc
+  hermes-engine: 77a22d21753247021cba9826fed004b94a012713
   Messaging-InApp-Core: 0fce52f6c73ed4359ddefd537bd63f302094e08d
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   NitroModules: 36c5d6bb6a3e21e38b1a3f47f5049d0d4a6d04b9
@@ -3306,7 +3306,7 @@ SPEC CHECKSUMS:
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
   React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
-  React-Core-prebuilt: d5679040a1eb49f090f02a0418ca7c8a4a02a3e7
+  React-Core-prebuilt: 726dd273519e75e8d853abc053de5a22b0b8121e
   React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
   React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
   React-debug: 92944dc4d89f56d640e75498266cbde557a48189
@@ -3381,9 +3381,9 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 25c9c516839be2c5e3d3344f95dc7da5f7e63fc2
   ReactCodegen: c8f81e6c6f762dcf442a6203a1fb58f7dafc8014
   ReactCommon: 7dfc3250793bf36cf221096ff59e1179e13eef7f
-  ReactNativeDependencies: 99d6d3962d4f5a5476c12fb661f11a15deb33cf2
+  ReactNativeDependencies: aebae57df35ac76ae01c600278201afd1cec04da
   RestartNewArch: 229b04862634bfcf903b0988d336e6559b2fe7e3
-  RNBootSplash: dcf4ccd62104bee81893e3d8c342860a491d3204
+  RNBootSplash: 65ee0b8120092c12ef024d082016a0ab6bcf035e
   RNCAsyncStorage: 2ad919e88b8bc2cd80e8697ce66d04d006743283
   RNCMaskedView: 4b5b12efdee55966f1d68f32d4b3401c2acf05c2
   RNDeviceInfo: 4c852998208b60dc192ae3529e5867817719ad1e

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2468,7 +2468,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNBootSplash (7.3.1):
+  - RNBootSplash (7.3.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3292,7 +3292,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 0608099d4870cac8754bdba9b6953db543432438
   GoogleUtilities: 4f2618a4a1e762a1ee134a1e2323bba9843e06da
-  hermes-engine: 77a22d21753247021cba9826fed004b94a012713
+  hermes-engine: a9252ff827cfcaf75e540b56e51acbf41bbf6fbc
   Messaging-InApp-Core: 0fce52f6c73ed4359ddefd537bd63f302094e08d
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   NitroModules: 36c5d6bb6a3e21e38b1a3f47f5049d0d4a6d04b9
@@ -3306,7 +3306,7 @@ SPEC CHECKSUMS:
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
   React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
-  React-Core-prebuilt: 726dd273519e75e8d853abc053de5a22b0b8121e
+  React-Core-prebuilt: d5679040a1eb49f090f02a0418ca7c8a4a02a3e7
   React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
   React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
   React-debug: 92944dc4d89f56d640e75498266cbde557a48189
@@ -3381,9 +3381,9 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 25c9c516839be2c5e3d3344f95dc7da5f7e63fc2
   ReactCodegen: c8f81e6c6f762dcf442a6203a1fb58f7dafc8014
   ReactCommon: 7dfc3250793bf36cf221096ff59e1179e13eef7f
-  ReactNativeDependencies: aebae57df35ac76ae01c600278201afd1cec04da
+  ReactNativeDependencies: 99d6d3962d4f5a5476c12fb661f11a15deb33cf2
   RestartNewArch: 229b04862634bfcf903b0988d336e6559b2fe7e3
-  RNBootSplash: 65ee0b8120092c12ef024d082016a0ab6bcf035e
+  RNBootSplash: dcf4ccd62104bee81893e3d8c342860a491d3204
   RNCAsyncStorage: 2ad919e88b8bc2cd80e8697ce66d04d006743283
   RNCMaskedView: 4b5b12efdee55966f1d68f32d4b3401c2acf05c2
   RNDeviceInfo: 4c852998208b60dc192ae3529e5867817719ad1e

--- a/src/components/ui/containers/WebView.tsx
+++ b/src/components/ui/containers/WebView.tsx
@@ -65,7 +65,10 @@ export const WebView = ({
       ref={ref}
       renderLoading={() => (
         <Column grow={1}>
-          <PleaseWait testID={testID} />
+          <PleaseWait
+            showFeedback
+            testID={testID}
+          />
         </Column>
       )}
       source={{uri: urlWithParams}}

--- a/src/components/ui/feedback/PleaseWait.stories.tsx
+++ b/src/components/ui/feedback/PleaseWait.stories.tsx
@@ -21,3 +21,17 @@ export const Default: StoryObj<typeof PleaseWait> = {
     grow: true,
   },
 }
+
+export const After5Seconds: StoryObj<typeof PleaseWait> = {
+  args: {
+    grow: true,
+    startedTimeStamp: Date.now() - 5000,
+  },
+}
+
+export const After15Seconds: StoryObj<typeof PleaseWait> = {
+  args: {
+    grow: true,
+    startedTimeStamp: Date.now() - 15000,
+  },
+}

--- a/src/components/ui/feedback/PleaseWait.test.tsx
+++ b/src/components/ui/feedback/PleaseWait.test.tsx
@@ -1,0 +1,108 @@
+import {act, render} from '@testing-library/react-native'
+import {type ComponentProps} from 'react'
+import {PleaseWait} from '@/components/ui/feedback/PleaseWait'
+import {StoreProvider} from '@/providers/store.provider'
+
+describe('PleaseWait', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-01-01T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  const renderPleaseWait = (
+    props: ComponentProps<typeof PleaseWait> | Record<string, unknown>,
+  ) =>
+    render(
+      <StoreProvider>
+        <PleaseWait {...(props as ComponentProps<typeof PleaseWait>)} />
+      </StoreProvider>,
+    )
+
+  it('renders the spinner with a valid testID', () => {
+    const {getByTestId, queryByTestId} = renderPleaseWait({
+      testID: 'PleaseWait',
+    })
+
+    expect(getByTestId('PleaseWait')).toBeTruthy()
+    expect(queryByTestId('PleaseWaitFeedbackPhrase')).toBeNull()
+  })
+
+  it('does not render feedback when showFeedback is undefined or null', () => {
+    const undefinedPropsRender = renderPleaseWait({showFeedback: undefined})
+
+    act(() => {
+      jest.advanceTimersByTime(16000)
+    })
+
+    expect(
+      undefinedPropsRender.queryByTestId('PleaseWaitFeedbackPhrase'),
+    ).toBeNull()
+
+    undefinedPropsRender.unmount()
+
+    const nullPropsRender = renderPleaseWait({showFeedback: null})
+
+    act(() => {
+      jest.advanceTimersByTime(16000)
+    })
+
+    expect(nullPropsRender.queryByTestId('PleaseWaitFeedbackPhrase')).toBeNull()
+  })
+
+  it('shows the first feedback message after five seconds when showFeedback is true, and still at 14.9 seconds', () => {
+    const {queryByText} = renderPleaseWait({showFeedback: true})
+
+    act(() => {
+      jest.advanceTimersByTime(5000)
+    })
+
+    expect(queryByText('Gegevens worden geladen')).toBeTruthy()
+
+    act(() => {
+      jest.advanceTimersByTime(9999)
+    })
+
+    expect(queryByText('Gegevens worden geladen')).toBeTruthy()
+
+    act(() => {
+      jest.advanceTimersByTime(1)
+    })
+
+    expect(queryByText('Gegevens worden geladen')).not.toBeTruthy()
+    expect(
+      queryByText('Dit duurt langer dan normaal. \n We zijn nog bezig.'),
+    ).toBeTruthy()
+  })
+
+  it('shows the second feedback message after fifteen seconds when startedTimeStamp is valid, and infinitely beyond that', () => {
+    const {queryByText} = renderPleaseWait({startedTimeStamp: Date.now()})
+
+    act(() => {
+      jest.advanceTimersByTime(5000)
+    })
+
+    expect(
+      queryByText('Dit duurt langer dan normaal. \n We zijn nog bezig.'),
+    ).not.toBeTruthy()
+
+    act(() => {
+      jest.advanceTimersByTime(10000)
+    })
+
+    expect(
+      queryByText('Dit duurt langer dan normaal. \n We zijn nog bezig.'),
+    ).toBeTruthy()
+
+    act(() => {
+      jest.advanceTimersByTime(60000)
+    })
+
+    expect(
+      queryByText('Dit duurt langer dan normaal. \n We zijn nog bezig.'),
+    ).toBeTruthy()
+  })
+})

--- a/src/components/ui/feedback/PleaseWait.tsx
+++ b/src/components/ui/feedback/PleaseWait.tsx
@@ -46,8 +46,7 @@ export const PleaseWait = ({
   testID,
 }: Props) => {
   const [elapsedTime, setElapsedTime] = useState(0)
-  const startTimeRef = useRef<number>(showFeedback ? Date.now() : null)
-
+  const startTimeRef = useRef<number | null>(showFeedback ? Date.now() : null)
   useEffect(() => {
     const countFrom = startedTimeStamp || startTimeRef.current
 

--- a/src/components/ui/feedback/PleaseWait.tsx
+++ b/src/components/ui/feedback/PleaseWait.tsx
@@ -82,7 +82,13 @@ export const PleaseWait = ({
             size="lg"
             testID={testID}
           />
-          {!!feedback && <Phrase textAlign="center">{feedback}</Phrase>}
+          {!!feedback && (
+            <Phrase
+              testID="PleaseWaitFeedbackPhrase"
+              textAlign="center">
+              {feedback}
+            </Phrase>
+          )}
         </Column>
       </Box>
     </Center>

--- a/src/components/ui/feedback/PleaseWait.tsx
+++ b/src/components/ui/feedback/PleaseWait.tsx
@@ -1,21 +1,72 @@
+import {useEffect, useMemo, useState} from 'react'
 import {Box} from '@/components/ui/containers/Box'
 import {Center} from '@/components/ui/layout/Center'
+import {Column} from '@/components/ui/layout/Column'
 import {Icon} from '@/components/ui/media/Icon'
+import {Phrase} from '@/components/ui/text/Phrase'
 import {type TestProps} from '@/components/ui/types'
+import {dayjs} from '@/utils/datetime/dayjs'
 
 type Props = {
   grow?: boolean
+  /**
+   * Add a startedTimeStamp (e.g. Date.now()) to get textual loading timeout feedback.
+   */
+  startedTimeStamp?: number
 } & TestProps
 
-export const PleaseWait = ({grow, testID}: Props) => (
-  <Center grow={grow}>
-    <Box>
-      <Icon
-        color="link"
-        name="spinner"
-        size="lg"
-        testID={testID}
-      />
-    </Box>
-  </Center>
-)
+const FIRST_TIMEOUT_VALUE = 5
+const SECOND_TIMEOUT_VALUE = 15
+
+const getElapsedTimeFeedback = (elapsedTime: number) => {
+  if (
+    elapsedTime >= FIRST_TIMEOUT_VALUE &&
+    elapsedTime < SECOND_TIMEOUT_VALUE
+  ) {
+    return 'Gegevens worden geladen'
+  } else if (elapsedTime >= SECOND_TIMEOUT_VALUE) {
+    return 'Dit duurt langer dan normaal. \n We zijn nog bezig.'
+  }
+}
+
+export const PleaseWait = ({grow, startedTimeStamp, testID}: Props) => {
+  const [elapsedTime, setElapsedTime] = useState(0)
+
+  useEffect(() => {
+    if (!startedTimeStamp) {
+      return
+    }
+
+    const interval = setInterval(() => {
+      setElapsedTime(Math.abs(dayjs(startedTimeStamp).diff()))
+    }, 1000)
+
+    return () => {
+      clearInterval(interval)
+      setElapsedTime(0)
+    }
+  }, [startedTimeStamp])
+
+  const elapsedSeconds = Math.floor(elapsedTime / 1000)
+
+  const feedback = useMemo(
+    () => getElapsedTimeFeedback(elapsedSeconds),
+    [elapsedSeconds],
+  )
+
+  return (
+    <Center grow={grow}>
+      <Box>
+        <Column gutter="md">
+          <Icon
+            color="link"
+            name="spinner"
+            size="lg"
+            testID={testID}
+          />
+          {!!feedback && <Phrase textAlign="center">{feedback}</Phrase>}
+        </Column>
+      </Box>
+    </Center>
+  )
+}

--- a/src/components/ui/feedback/PleaseWait.tsx
+++ b/src/components/ui/feedback/PleaseWait.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useState} from 'react'
+import {useEffect, useMemo, useRef, useState} from 'react'
 import {Box} from '@/components/ui/containers/Box'
 import {Center} from '@/components/ui/layout/Center'
 import {Column} from '@/components/ui/layout/Column'
@@ -9,11 +9,21 @@ import {dayjs} from '@/utils/datetime/dayjs'
 
 type Props = {
   grow?: boolean
-  /**
-   * Add a startedTimeStamp (e.g. Date.now()) to get textual loading timeout feedback.
-   */
-  startedTimeStamp?: number
-} & TestProps
+} & TestProps &
+  Or<
+    {
+      /**
+       * Add a timestamp to start a timer which shows textual loading timeout feedback.
+       */
+      startedTimeStamp?: number
+    },
+    {
+      /**
+       * Starts a timer from time of mount (as ref) and show textual loading timeout feedback.
+       */
+      showFeedback?: true
+    }
+  >
 
 const FIRST_TIMEOUT_VALUE = 5
 const SECOND_TIMEOUT_VALUE = 15
@@ -29,23 +39,31 @@ const getElapsedTimeFeedback = (elapsedTime: number) => {
   }
 }
 
-export const PleaseWait = ({grow, startedTimeStamp, testID}: Props) => {
+export const PleaseWait = ({
+  grow,
+  startedTimeStamp,
+  showFeedback,
+  testID,
+}: Props) => {
   const [elapsedTime, setElapsedTime] = useState(0)
+  const startTimeRef = useRef<number>(showFeedback ? Date.now() : null)
 
   useEffect(() => {
-    if (!startedTimeStamp) {
+    const countFrom = startedTimeStamp || startTimeRef.current
+
+    if (!countFrom) {
       return
     }
 
     const interval = setInterval(() => {
-      setElapsedTime(Math.abs(dayjs(startedTimeStamp).diff()))
+      setElapsedTime(Math.abs(dayjs(countFrom).diff()))
     }, 1000)
 
     return () => {
       clearInterval(interval)
       setElapsedTime(0)
     }
-  }, [startedTimeStamp])
+  }, [startedTimeStamp, startTimeRef])
 
   const elapsedSeconds = Math.floor(elapsedTime / 1000)
 

--- a/src/components/ui/feedback/PleaseWait.tsx
+++ b/src/components/ui/feedback/PleaseWait.tsx
@@ -60,7 +60,6 @@ export const PleaseWait = ({
 
     return () => {
       clearInterval(interval)
-      setElapsedTime(0)
     }
   }, [startedTimeStamp, startTimeRef])
 

--- a/src/modules/boat-charging/components/BoatChargingDetails.tsx
+++ b/src/modules/boat-charging/components/BoatChargingDetails.tsx
@@ -69,7 +69,12 @@ export const BoatChargingDetails = ({id}: {id: BoatChargingLocation['id']}) => {
   const form = useNewSessionFormContext()
 
   if (isLoadingLocation || isLoadingSessions) {
-    return <PleaseWait testID="BoatChargingDetailsPleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="BoatChargingDetailsPleaseWait"
+      />
+    )
   }
 
   if (isErrorLocation || isErrorSessions || !location) {

--- a/src/modules/boat-charging/components/BoatChargingHistorySessionDetails.tsx
+++ b/src/modules/boat-charging/components/BoatChargingHistorySessionDetails.tsx
@@ -68,7 +68,12 @@ export const BoatChargingHistorySessionDetails = () => {
   const {toggle} = useBottomSheet()
 
   if (isLoading) {
-    return <PleaseWait testID="BoatChargingHistorySessionDetailsPleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="BoatChargingHistorySessionDetailsPleaseWait"
+      />
+    )
   }
 
   if (!session) {

--- a/src/modules/boat-charging/components/BoatChargingList.tsx
+++ b/src/modules/boat-charging/components/BoatChargingList.tsx
@@ -60,7 +60,12 @@ export const BoatChargingList = ({
   }, [filteredFeatures, address])
 
   if (isLoading) {
-    return <PleaseWait testID="BoatChargingListPleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="BoatChargingListPleaseWait"
+      />
+    )
   }
 
   if (isError) {

--- a/src/modules/boat-charging/components/BoatChargingList.tsx
+++ b/src/modules/boat-charging/components/BoatChargingList.tsx
@@ -64,7 +64,12 @@ export const BoatChargingList = ({
   }
 
   if (isError) {
-    return <SomethingWentWrong testID="BoatChargingListSomethingWentWrong" />
+    return (
+      <SomethingWentWrong
+        inset="md"
+        testID="BoatChargingListSomethingWentWrong"
+      />
+    )
   }
 
   return (

--- a/src/modules/boat-charging/components/BoatChargingMap.tsx
+++ b/src/modules/boat-charging/components/BoatChargingMap.tsx
@@ -59,7 +59,12 @@ export const BoatChargingMap = ({
   }
 
   if (isError) {
-    return <SomethingWentWrong testID="BoatChargingMapSomethingWentWrong" />
+    return (
+      <SomethingWentWrong
+        inset="md"
+        testID="BoatChargingMapSomethingWentWrong"
+      />
+    )
   }
 
   return (

--- a/src/modules/boat-charging/components/BoatChargingMap.tsx
+++ b/src/modules/boat-charging/components/BoatChargingMap.tsx
@@ -55,7 +55,12 @@ export const BoatChargingMap = ({
   })
 
   if (isLoading) {
-    return <PleaseWait testID="BoatChargingMapPleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="BoatChargingMapPleaseWait"
+      />
+    )
   }
 
   if (isError) {

--- a/src/modules/boat-charging/components/bottomsheet/BoatChargingPointDetails.tsx
+++ b/src/modules/boat-charging/components/bottomsheet/BoatChargingPointDetails.tsx
@@ -37,6 +37,7 @@ export const BoatChargingPointDetails = () => {
     data: location,
     isLoading,
     isError,
+    startedTimeStamp,
   } = useBoatChargingLocationDetailsQuery(id ?? skipToken)
 
   const autoFocus = useAccessibilityFocus()
@@ -68,7 +69,12 @@ export const BoatChargingPointDetails = () => {
   const {reset} = useNewSessionFormContext()
 
   if (isLoading) {
-    return <PleaseWait testID="BoatChargingPointDetailsPleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="BoatChargingPointDetailsPleaseWait"
+      />
+    )
   }
 
   if (isError || !location) {

--- a/src/modules/boat-charging/components/bottomsheet/BoatChargingPointDetails.tsx
+++ b/src/modules/boat-charging/components/bottomsheet/BoatChargingPointDetails.tsx
@@ -73,9 +73,10 @@ export const BoatChargingPointDetails = () => {
 
   if (isError || !location) {
     return (
-      <Box>
-        <SomethingWentWrong testID="BoatChargingPointDetailsSomethingWentWrong" />
-      </Box>
+      <SomethingWentWrong
+        inset="md"
+        testID="BoatChargingPointDetailsSomethingWentWrong"
+      />
     )
   }
 

--- a/src/modules/boat-charging/components/history/BoatChargingHistory.tsx
+++ b/src/modules/boat-charging/components/history/BoatChargingHistory.tsx
@@ -148,7 +148,12 @@ export const BoatChargingHistory = () => {
   }
 
   if (result.isLoading && result.data.length === 0) {
-    return <PleaseWait testID="BoatChargingHistoryPleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="BoatChargingHistoryPleaseWait"
+      />
+    )
   }
 
   if (result.isError) {

--- a/src/modules/boat-charging/components/session/BoatChargingSession.tsx
+++ b/src/modules/boat-charging/components/session/BoatChargingSession.tsx
@@ -44,9 +44,10 @@ export const BoatChargingSession = () => {
 
   if (isError || !session) {
     return (
-      <Box>
-        <SomethingWentWrong testID="BoatChargingSessionSomethingWentWrong" />
-      </Box>
+      <SomethingWentWrong
+        inset="md"
+        testID="BoatChargingSessionSomethingWentWrong"
+      />
     )
   }
 

--- a/src/modules/boat-charging/components/session/BoatChargingSession.tsx
+++ b/src/modules/boat-charging/components/session/BoatChargingSession.tsx
@@ -39,7 +39,12 @@ export const BoatChargingSession = () => {
   }, [session?.status, navigation, session?.id])
 
   if (isLoading) {
-    return <PleaseWait testID="BoatChargingSessionPleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="BoatChargingSessionPleaseWait"
+      />
+    )
   }
 
   if (isError || !session) {

--- a/src/modules/boat-charging/screens/BoatChargingGuestEmailConfirm.screen.tsx
+++ b/src/modules/boat-charging/screens/BoatChargingGuestEmailConfirm.screen.tsx
@@ -24,7 +24,10 @@ export const BoatChargingGuestEmailConfirmScreen = () => {
 
   if (!email) {
     return (
-      <SomethingWentWrong testID="BoatChargingGuestEmailConfirmScreenSomethingWentWrong" />
+      <SomethingWentWrong
+        inset="md"
+        testID="BoatChargingGuestEmailConfirmScreenSomethingWentWrong"
+      />
     )
   }
 

--- a/src/modules/boat-charging/screens/BoatChargingTermsAndConditions.screen.tsx
+++ b/src/modules/boat-charging/screens/BoatChargingTermsAndConditions.screen.tsx
@@ -80,7 +80,10 @@ export const BoatChargingTermsAndConditionsScreen = ({}: Props) => {
         />
         <Gutter height="sm" />
         {isLoading ? (
-          <PleaseWait testID="BoatChargingTermsAndConditionsPleaseWait" />
+          <PleaseWait
+            showFeedback
+            testID="BoatChargingTermsAndConditionsPleaseWait"
+          />
         ) : isError ? (
           <Box insetVertical="md">
             <SomethingWentWrong testID="BoatChargingTermsAndConditionsSomethingWentWrong" />

--- a/src/modules/burning-guide/components/BurningGuide.tsx
+++ b/src/modules/burning-guide/components/BurningGuide.tsx
@@ -24,7 +24,12 @@ export const BurningGuide = () => {
   }
 
   if (isLoading || isFetching) {
-    return <PleaseWait testID="BurningGuideForecastListPleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="BurningGuideForecastListPleaseWait"
+      />
+    )
   }
 
   if (isPostalCodeError) {

--- a/src/modules/city-pass/components/Budget.tsx
+++ b/src/modules/city-pass/components/Budget.tsx
@@ -21,6 +21,7 @@ export const Budget = ({budgetCode, passNumber}: Props) => {
     error,
     isLoading,
     isError,
+    startedTimeStamp,
     refetch,
   } = useGetCityPassesQuery()
   const cityPass = cityPasses?.find(cp => cp.passNumber === passNumber)
@@ -28,7 +29,12 @@ export const Budget = ({budgetCode, passNumber}: Props) => {
   useSetScreenTitle(cityPass?.owner.firstname)
 
   if (isLoading) {
-    return <PleaseWait testID="CityPassDashboardPleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="CityPassDashboardPleaseWait"
+      />
+    )
   }
 
   if (isError || !cityPass) {

--- a/src/modules/city-pass/components/details/CityPassDetails.tsx
+++ b/src/modules/city-pass/components/details/CityPassDetails.tsx
@@ -17,7 +17,12 @@ type Props = {
 }
 
 export const CityPassDetails = ({passNumber}: Props) => {
-  const {data: cityPasses, isLoading, isError} = useGetCityPassesQuery()
+  const {
+    data: cityPasses,
+    isLoading,
+    isError,
+    startedTimeStamp,
+  } = useGetCityPassesQuery()
 
   const cityPass = cityPasses?.find(cp => cp.passNumber === passNumber)
   const cityPassIndex = cityPasses?.findIndex(
@@ -28,7 +33,10 @@ export const CityPassDetails = ({passNumber}: Props) => {
     return (
       <Box grow>
         <Column gutter="md">
-          <PleaseWait testID="CityPassDashboardPleaseWait" />
+          <PleaseWait
+            startedTimeStamp={startedTimeStamp}
+            testID="CityPassDashboardPleaseWait"
+          />
           <ShowCityPassButton index={cityPassIndex} />
         </Column>
       </Box>

--- a/src/modules/city-pass/components/details/SecurityCode.tsx
+++ b/src/modules/city-pass/components/details/SecurityCode.tsx
@@ -68,6 +68,7 @@ export const SecurityCode = ({id}: Props) => {
   if (isError) {
     return (
       <SomethingWentWrong
+        inset="md"
         testID="CityPassSecurityCodeSomethingWentWrong"
         text={SOMETHING_WENT_WRONG_TEXT}
         title=""

--- a/src/modules/city-pass/components/details/SecurityCode.tsx
+++ b/src/modules/city-pass/components/details/SecurityCode.tsx
@@ -35,6 +35,7 @@ export const SecurityCode = ({id}: Props) => {
     data: cityPasses,
     isFetching,
     isError,
+    startedTimeStamp,
   } = useGetCityPassesQuery(id ? undefined : skipToken)
   const cityPass = cityPasses?.find(cp => cp.id === id)
   const securityCode = cityPass?.securityCode
@@ -62,7 +63,12 @@ export const SecurityCode = ({id}: Props) => {
   }, [securityCode, authenticate])
 
   if (isFetching) {
-    return <PleaseWait testID="CityPassSecurityCodePleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="CityPassSecurityCodePleaseWait"
+      />
+    )
   }
 
   if (isError) {

--- a/src/modules/city-pass/components/transactions/BudgetTransactions.tsx
+++ b/src/modules/city-pass/components/transactions/BudgetTransactions.tsx
@@ -26,10 +26,16 @@ export const BudgetTransactions = ({
     data: budgetTransactions,
     isLoading,
     isError,
+    startedTimeStamp,
   } = useGetBudgetTransactionsQuery({passNumber, budgetCode})
 
   if (isLoading) {
-    return <PleaseWait testID="CityPassBudgetPleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="CityPassBudgetPleaseWait"
+      />
+    )
   }
 
   if (isError || !budgetTransactions) {

--- a/src/modules/city-pass/components/transactions/DiscountTransactions.tsx
+++ b/src/modules/city-pass/components/transactions/DiscountTransactions.tsx
@@ -18,12 +18,18 @@ const DiscountTransactionsContent = ({
   passNumber,
   isActive,
 }: Props) => {
-  const {data, isLoading, isError, refetch} = useGetDiscountTransactionsQuery({
-    passNumber,
-  })
+  const {data, isLoading, isError, refetch, startedTimeStamp} =
+    useGetDiscountTransactionsQuery({
+      passNumber,
+    })
 
   if (isLoading) {
-    return <PleaseWait testID="CityPassDiscountTransactionsPleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="CityPassDiscountTransactionsPleaseWait"
+      />
+    )
   }
 
   if (isError || !data) {

--- a/src/modules/city-pass/screenConfig.ts
+++ b/src/modules/city-pass/screenConfig.ts
@@ -45,6 +45,9 @@ export const cityPassScreenConfig: StackNavigationRoutes<
   [CityPassRouteName.budget]: {
     component: BudgetScreen,
     name: CityPassRouteName.budget,
+    options: {
+      headerShown: false,
+    },
   },
 
   [CityPassRouteName.cityPassLogout]: {

--- a/src/modules/city-pass/screenConfig.ts
+++ b/src/modules/city-pass/screenConfig.ts
@@ -65,6 +65,9 @@ export const cityPassScreenConfig: StackNavigationRoutes<
   [CityPassRouteName.securityCode]: {
     component: SecurityCodeScreen,
     name: CityPassRouteName.securityCode,
+    options: {
+      headerShown: false,
+    },
   },
   [CityPassRouteName.cityPassBlockPass]: {
     component: CityPassBlockPassScreen,

--- a/src/modules/construction-work-editor/components/AuthorizedProjects.tsx
+++ b/src/modules/construction-work-editor/components/AuthorizedProjects.tsx
@@ -68,7 +68,10 @@ export const AuthorizedProjects = ({initialMetrics}: Props) => {
 
   if (isError) {
     return (
-      <SomethingWentWrong testID="ConstructionWorkEditorAuthorizedProjectsSomethingWentWrong" />
+      <SomethingWentWrong
+        inset="md"
+        testID="ConstructionWorkEditorAuthorizedProjectsSomethingWentWrong"
+      />
     )
   }
 

--- a/src/modules/construction-work-editor/components/AuthorizedProjects.tsx
+++ b/src/modules/construction-work-editor/components/AuthorizedProjects.tsx
@@ -56,13 +56,21 @@ export const AuthorizedProjects = ({initialMetrics}: Props) => {
   const {size} = useTheme()
   const itemDimension = 16 * size.spacing.md * Math.max(fontScale, 1)
 
-  const {data: authorizedProjects, isFetching, isError} = useGetProjectsQuery()
+  const {
+    data: authorizedProjects,
+    isFetching,
+    isError,
+    startedTimeStamp,
+  } = useGetProjectsQuery()
 
   useRegisterConstructionWorkEditor()
 
   if (isFetching) {
     return (
-      <PleaseWait testID="ConstructionWorkEditorAuthorizedProjectsLoadingSpinner" />
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="ConstructionWorkEditorAuthorizedProjectsLoadingSpinner"
+      />
     )
   }
 

--- a/src/modules/construction-work/components/article/ArticleOverview.tsx
+++ b/src/modules/construction-work/components/article/ArticleOverview.tsx
@@ -37,6 +37,7 @@ export const ArticleOverview = ({projectId, projectTitle, title}: Props) => {
     isError,
     isLoading,
     refetch,
+    startedTimeStamp,
   } = useArticlesQuery(
     projectId
       ? {
@@ -98,7 +99,12 @@ export const ArticleOverview = ({projectId, projectTitle, title}: Props) => {
   }
 
   if (isLoading) {
-    return <PleaseWait testID="ConstructionWorkProjectArticlesSpinner" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="ConstructionWorkProjectArticlesSpinner"
+      />
+    )
   }
 
   if (!isError && !yearlyArticleSections?.length) {

--- a/src/modules/construction-work/components/project/Project.tsx
+++ b/src/modules/construction-work/components/project/Project.tsx
@@ -32,10 +32,16 @@ export const Project = ({id}: Props) => {
     isLoading,
     isFetching,
     error: projectError,
+    startedTimeStamp,
   } = useProjectDetailsQuery({id, ...addressParam})
 
   if (isLoading) {
-    return <PleaseWait testID="ConstructionWorkProjectLoadingSpinner" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="ConstructionWorkProjectLoadingSpinner"
+      />
+    )
   }
 
   if (!project) {

--- a/src/modules/construction-work/components/project/ProjectArticle.tsx
+++ b/src/modules/construction-work/components/project/ProjectArticle.tsx
@@ -36,7 +36,11 @@ export const ProjectArticle = ({
   publicationDate,
   title,
 }: Props) => {
-  const {data: project, isLoading: isLoadingProject} = useProjectDetailsQuery(
+  const {
+    data: project,
+    isLoading: isLoadingProject,
+    startedTimeStamp,
+  } = useProjectDetailsQuery(
     projectId
       ? {
           id: projectId,
@@ -62,7 +66,10 @@ export const ProjectArticle = ({
         testID={`ConstructionWorkProjectArticle${id}Image`}
       />
       {isLoadingProject ? (
-        <PleaseWait testID={`ConstructionWorkProjectArticle${id}PleaseWait`} />
+        <PleaseWait
+          startedTimeStamp={startedTimeStamp}
+          testID={`ConstructionWorkProjectArticle${id}PleaseWait`}
+        />
       ) : (
         <HorizontalSafeArea>
           <Box>

--- a/src/modules/construction-work/components/project/ProjectNews.tsx
+++ b/src/modules/construction-work/components/project/ProjectNews.tsx
@@ -23,6 +23,7 @@ export const ProjectNews = ({id, projectId: passedProjectId}: Props) => {
     isError: articleIsError,
     isLoading: articleIsLoading,
     error: articleError,
+    startedTimeStamp,
   } = useProjectNewsQuery({
     id,
   })
@@ -43,7 +44,12 @@ export const ProjectNews = ({id, projectId: passedProjectId}: Props) => {
   }, [article, id, markAsRead])
 
   if (articleIsLoading) {
-    return <PleaseWait testID="ConstructionWorkNewsLoadingSpinner" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="ConstructionWorkNewsLoadingSpinner"
+      />
+    )
   }
 
   if (!article || articleIsError) {

--- a/src/modules/construction-work/components/project/ProjectWarning.tsx
+++ b/src/modules/construction-work/components/project/ProjectWarning.tsx
@@ -43,7 +43,10 @@ export const ProjectWarning = ({id, projectId: passedProjectId}: Props) => {
 
   if (!warningData || warningIsError) {
     return (
-      <SomethingWentWrong testID="ConstructionWorkWarningSomethingWentWrong" />
+      <SomethingWentWrong
+        inset="md"
+        testID="ConstructionWorkWarningSomethingWentWrong"
+      />
     )
   }
 

--- a/src/modules/construction-work/components/project/ProjectWarning.tsx
+++ b/src/modules/construction-work/components/project/ProjectWarning.tsx
@@ -38,7 +38,12 @@ export const ProjectWarning = ({id, projectId: passedProjectId}: Props) => {
   // useSetScreenTitle(projectData?.title)
 
   if (projectIsLoading || warningIsLoading) {
-    return <PleaseWait testID="ConstructionWorkWarningLoadingSpinner" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="ConstructionWorkWarningLoadingSpinner"
+      />
+    )
   }
 
   if (!warningData || warningIsError) {

--- a/src/modules/construction-work/components/projects/ListEmptyComponent.tsx
+++ b/src/modules/construction-work/components/projects/ListEmptyComponent.tsx
@@ -15,7 +15,12 @@ export const ListEmptyComponent = ({
   noResultsMessage,
 }: Props) => {
   if (isLoading) {
-    return <PleaseWait testID="ConstructionWorkListLoadingSpinner" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="ConstructionWorkListLoadingSpinner"
+      />
+    )
   }
 
   if (searchText !== '') {

--- a/src/modules/contact/components/city-offices/CityOffice.tsx
+++ b/src/modules/contact/components/city-offices/CityOffice.tsx
@@ -15,10 +15,20 @@ import {selectCityOffice} from '@/modules/contact/slice'
 
 export const CityOffice = () => {
   const selectedCityOfficeId = useSelector(selectCityOffice)
-  const {data: cityOffices, isLoading, refetch} = useGetCityOfficesQuery()
+  const {
+    data: cityOffices,
+    isLoading,
+    refetch,
+    startedTimeStamp,
+  } = useGetCityOfficesQuery()
 
   if (isLoading) {
-    return <PleaseWait testID="ContactCityOfficesLoadingSpinner" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="ContactCityOfficesLoadingSpinner"
+      />
+    )
   }
 
   const cityOfficeId = selectedCityOfficeId ?? cityOffices?.[0]?.identifier

--- a/src/modules/contact/components/city-offices/SelectCityOffice.tsx
+++ b/src/modules/contact/components/city-offices/SelectCityOffice.tsx
@@ -9,10 +9,19 @@ import {useGetCityOfficesQuery} from '@/modules/contact/service'
 
 export const SelectCityOffice = () => {
   const focusRef = useSetBottomSheetElementFocus()
-  const {data: cityOffices, isLoading} = useGetCityOfficesQuery()
+  const {
+    data: cityOffices,
+    isLoading,
+    startedTimeStamp,
+  } = useGetCityOfficesQuery()
 
   if (isLoading || !cityOffices) {
-    return <PleaseWait testID="ContactSelectCityOfficesLoadingSpinner" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="ContactSelectCityOfficesLoadingSpinner"
+      />
+    )
   }
 
   return (

--- a/src/modules/elections/components/PollingStationsList.tsx
+++ b/src/modules/elections/components/PollingStationsList.tsx
@@ -50,7 +50,12 @@ export const PollingStationsList = ({
   }
 
   if (!pollingStations || !pollingStations.length || isError) {
-    return <SomethingWentWrong testID="PollingStationsListSomethingWentWrong" />
+    return (
+      <SomethingWentWrong
+        inset="md"
+        testID="PollingStationsListSomethingWentWrong"
+      />
+    )
   }
 
   return (

--- a/src/modules/elections/components/PollingStationsList.tsx
+++ b/src/modules/elections/components/PollingStationsList.tsx
@@ -46,7 +46,12 @@ export const PollingStationsList = ({
   }, [pollingStations, address])
 
   if (isLoading) {
-    return <PleaseWait testID="PollingStationsListPleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="PollingStationsListPleaseWait"
+      />
+    )
   }
 
   if (!pollingStations || !pollingStations.length || isError) {

--- a/src/modules/elections/components/PollingStationsMap.tsx
+++ b/src/modules/elections/components/PollingStationsMap.tsx
@@ -41,7 +41,12 @@ export const PollingStationsMap = ({
   }
 
   if (!pollingStations?.length || isError) {
-    return <SomethingWentWrong testID="PollingStationsMapSomethingWentWrong" />
+    return (
+      <SomethingWentWrong
+        inset="md"
+        testID="PollingStationsMapSomethingWentWrong"
+      />
+    )
   }
 
   return (

--- a/src/modules/elections/components/PollingStationsMap.tsx
+++ b/src/modules/elections/components/PollingStationsMap.tsx
@@ -37,7 +37,12 @@ export const PollingStationsMap = ({
   useSetMapSelection(String(selectedPollingStationId))
 
   if (isLoading) {
-    return <PleaseWait testID="PollingStationsMapPleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="PollingStationsMapPleaseWait"
+      />
+    )
   }
 
   if (!pollingStations?.length || isError) {

--- a/src/modules/home/components/Home.tsx
+++ b/src/modules/home/components/Home.tsx
@@ -11,7 +11,12 @@ export const Home = () => {
     useModules()
 
   if (modulesLoading) {
-    return <PleaseWait testID="HomeLoadingSpinner" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="HomeLoadingSpinner"
+      />
+    )
   }
 
   if (modulesError || !enabledModules) {

--- a/src/modules/news/components/NewsArticle.tsx
+++ b/src/modules/news/components/NewsArticle.tsx
@@ -17,7 +17,12 @@ export const NewsArticle = ({id}: Props) => {
   const {article, isLoading, isError} = useNewsArticle()
 
   if (isLoading) {
-    return <PleaseWait testID="NewsArticlePleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="NewsArticlePleaseWait"
+      />
+    )
   }
 
   if (isError || !article) {

--- a/src/modules/news/components/NewsDashboardHighlightedArticle.tsx
+++ b/src/modules/news/components/NewsDashboardHighlightedArticle.tsx
@@ -11,7 +11,8 @@ import {useHighlightedArticle} from '@/modules/news/hooks/useHighlightedArticle'
 import {NewsRouteName} from '@/modules/news/routes'
 
 export const NewsDashboardHighlightedArticle = () => {
-  const {isError, isLoading, highlightedArticle} = useHighlightedArticle()
+  const {isError, isLoading, highlightedArticle, startedTimeStamp} =
+    useHighlightedArticle()
   const {navigate} = useNavigation()
 
   const navigateTo = useCallback(() => {
@@ -31,7 +32,12 @@ export const NewsDashboardHighlightedArticle = () => {
   }, [highlightedArticle, navigate])
 
   if (isLoading) {
-    return <PleaseWait testID="NewsDashboardHighlightedArticlePleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="NewsDashboardHighlightedArticlePleaseWait"
+      />
+    )
   }
 
   if (isError) {

--- a/src/modules/news/components/NewsHighlights.tsx
+++ b/src/modules/news/components/NewsHighlights.tsx
@@ -9,10 +9,16 @@ export const NewsHighlights = () => {
     data: highlights,
     isLoading,
     isError,
+    startedTimeStamp,
   } = useNewsArticlesQuery({type: 'highlight'})
 
   if (isLoading) {
-    return <PleaseWait testID="NewsHighlightsPleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="NewsHighlightsPleaseWait"
+      />
+    )
   }
 
   if (isError || !highlights?.result.length) {

--- a/src/modules/news/components/NewsHighlights.tsx
+++ b/src/modules/news/components/NewsHighlights.tsx
@@ -16,7 +16,12 @@ export const NewsHighlights = () => {
   }
 
   if (isError || !highlights?.result.length) {
-    return <SomethingWentWrong testID="NewsHighlightsSomethingWentWrong" />
+    return (
+      <SomethingWentWrong
+        inset="md"
+        testID="NewsHighlightsSomethingWentWrong"
+      />
+    )
   }
 
   return (

--- a/src/modules/news/components/NewsList.tsx
+++ b/src/modules/news/components/NewsList.tsx
@@ -80,7 +80,12 @@ export const NewsList = ({
       data={result.data ?? []}
       ItemSeparatorComponent={<Gutter height="md" />}
       ListEmptyComponent={
-        result.isLoading ? <PleaseWait testID="NewsListPleaseWait" /> : null
+        result.isLoading ? (
+          <PleaseWait
+            showFeedback
+            testID="NewsListPleaseWait"
+          />
+        ) : null
       }
       ListFooterComponent={footerComponent}
       ListHeaderComponent={headerComponent}

--- a/src/modules/news/components/SelectDistrictBottomSheet.tsx
+++ b/src/modules/news/components/SelectDistrictBottomSheet.tsx
@@ -13,7 +13,7 @@ import {useNewsDistrictsQuery} from '@/modules/news/service'
 import {setSelectedDistrict} from '@/modules/news/slice'
 
 export const SelectDistrictBottomSheet = () => {
-  const {data, isLoading} = useNewsDistrictsQuery()
+  const {data, isLoading, startedTimeStamp} = useNewsDistrictsQuery()
   const districts = data?.data
     ?.slice()
     ?.sort((a, b) => a.name.localeCompare(b.name))
@@ -30,7 +30,10 @@ export const SelectDistrictBottomSheet = () => {
           />
           <Column gutter="no">
             {isLoading ? (
-              <PleaseWait testID="NewsSelectDistrictPleaseWait" />
+              <PleaseWait
+                startedTimeStamp={startedTimeStamp}
+                testID="NewsSelectDistrictPleaseWait"
+              />
             ) : (
               districts?.map(district => (
                 <Pressable

--- a/src/modules/news/components/liveblog/Liveblog.tsx
+++ b/src/modules/news/components/liveblog/Liveblog.tsx
@@ -49,7 +49,12 @@ export const Liveblog = ({id}: {id: NewsArticleBase['id']}) => {
   }
 
   if (isError || !data) {
-    return <SomethingWentWrong testID="LiveblogSomethingWentWrong" />
+    return (
+      <SomethingWentWrong
+        inset="md"
+        testID="LiveblogSomethingWentWrong"
+      />
+    )
   }
 
   return (

--- a/src/modules/news/components/liveblog/Liveblog.tsx
+++ b/src/modules/news/components/liveblog/Liveblog.tsx
@@ -17,7 +17,7 @@ import {getLiveblogLastEntriesPerDay} from '@/modules/news/utils/getLiveblogLast
 import {useThemable} from '@/themes/useThemable'
 
 export const Liveblog = ({id}: {id: NewsArticleBase['id']}) => {
-  const {data, isError, isLoading, ...rest} = useLiveblog(id)
+  const {data, isError, isLoading, startedTimeStamp, ...rest} = useLiveblog(id)
   const styles = useThemable(createStyles)
   const navigation = useNavigation()
 
@@ -45,7 +45,12 @@ export const Liveblog = ({id}: {id: NewsArticleBase['id']}) => {
   )
 
   if (isLoading) {
-    return <PleaseWait testID="LiveblogPleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="LiveblogPleaseWait"
+      />
+    )
   }
 
   if (isError || !data) {

--- a/src/modules/notification-history/components/NotificationHistory.tsx
+++ b/src/modules/notification-history/components/NotificationHistory.tsx
@@ -11,7 +11,8 @@ import {useGetNotificationsQuery} from '@/modules/notification-history/service'
 
 export const NotificationHistory = () => {
   const navigation = useNavigation()
-  const {data, isLoading, isError, error, refetch} = useGetNotificationsQuery()
+  const {data, isLoading, isError, error, refetch, startedTimeStamp} =
+    useGetNotificationsQuery()
 
   useFocusEffect(
     useCallback(() => {
@@ -23,7 +24,10 @@ export const NotificationHistory = () => {
     return (
       <>
         <NotificationHistoryBanner />
-        <PleaseWait testID="NotificationHistoryPleaseWait" />
+        <PleaseWait
+          startedTimeStamp={startedTimeStamp}
+          testID="NotificationHistoryPleaseWait"
+        />
       </>
     )
   }

--- a/src/modules/parking/components/ParkingMyLicensePlates.tsx
+++ b/src/modules/parking/components/ParkingMyLicensePlates.tsx
@@ -20,7 +20,11 @@ import {RedirectKey} from '@/modules/redirects/types'
 
 export const ParkingMyLicensePlates = () => {
   const currentPermit = useCurrentParkingPermit()
-  const {data: licensePlates, isFetching} = useLicensePlatesQuery(
+  const {
+    data: licensePlates,
+    isFetching,
+    startedTimeStamp,
+  } = useLicensePlatesQuery(
     currentPermit
       ? {
           reportCode: currentPermit.report_code.toString(),
@@ -83,7 +87,12 @@ export const ParkingMyLicensePlates = () => {
   )
 
   if (isFetching || isLoadingRemoveLicensePlate) {
-    return <PleaseWait testID="ParkingSelectLicensePlatePleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="ParkingSelectLicensePlatePleaseWait"
+      />
+    )
   }
 
   if (!licensePlates) {

--- a/src/modules/parking/components/ParkingMyLicensePlates.tsx
+++ b/src/modules/parking/components/ParkingMyLicensePlates.tsx
@@ -88,7 +88,10 @@ export const ParkingMyLicensePlates = () => {
 
   if (!licensePlates) {
     return (
-      <SomethingWentWrong testID="ParkingSelectLicensePlateSomethingWentWrong" />
+      <SomethingWentWrong
+        inset="md"
+        testID="ParkingSelectLicensePlateSomethingWentWrong"
+      />
     )
   }
 

--- a/src/modules/parking/components/dashboard/ParkingPermitBalanceMoney.tsx
+++ b/src/modules/parking/components/dashboard/ParkingPermitBalanceMoney.tsx
@@ -22,7 +22,12 @@ export const ParkingPermitBalanceMoney = () => {
   const dispatch = useDispatch()
   const currentPermit = useCurrentParkingPermit()
   const walletBalance = useWalletBalanceIncreaseStartBalance()
-  const {data: account, isLoading, refetch} = useAccountDetailsQuery()
+  const {
+    data: account,
+    isLoading,
+    refetch,
+    startedTimeStamp,
+  } = useAccountDetailsQuery()
   const accountWalletBalance = account?.wallet?.balance
   const walletBalanceIncreaseStartedAt = useWalletBalanceIncreaseStartedAt()
 
@@ -48,7 +53,12 @@ export const ParkingPermitBalanceMoney = () => {
   )
 
   if (isLoading) {
-    return <PleaseWait testID="ParkingPermitBalanceMoneyPleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="ParkingPermitBalanceMoneyPleaseWait"
+      />
+    )
   }
 
   if (!account) {

--- a/src/modules/parking/components/form/ParkingIncreaseBalanceReceipt.tsx
+++ b/src/modules/parking/components/form/ParkingIncreaseBalanceReceipt.tsx
@@ -14,10 +14,19 @@ export const ParkingIncreaseBalanceReceipt = () => {
   const {watch} = useFormContext<{amount?: number}>()
   const amount = watch('amount')
 
-  const {data: account, isLoading: isLoadingAccount} = useAccountDetailsQuery()
+  const {
+    data: account,
+    isLoading: isLoadingAccount,
+    startedTimeStamp,
+  } = useAccountDetailsQuery()
 
   if (isLoadingAccount) {
-    return <PleaseWait testID="ParkingIncreaseBalanceReceiptPleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="ParkingIncreaseBalanceReceiptPleaseWait"
+      />
+    )
   }
 
   if (!account?.wallet) {

--- a/src/modules/parking/components/form/ParkingReceipt.tsx
+++ b/src/modules/parking/components/form/ParkingReceipt.tsx
@@ -179,7 +179,12 @@ export const ParkingReceipt = () => {
   }, [isVisitor, data?.costs?.value, setValue])
 
   if (isLoading || isLoadingAccount) {
-    return <PleaseWait testID="ParkingSessionReceiptPleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="ParkingSessionReceiptPleaseWait"
+      />
+    )
   }
 
   if (

--- a/src/modules/parking/components/form/ParkingSessionAddLicensePlate.tsx
+++ b/src/modules/parking/components/form/ParkingSessionAddLicensePlate.tsx
@@ -26,7 +26,12 @@ export const ParkingSessionAddLicensePlate = () => {
   }, [isOpen])
 
   if (isLoading) {
-    return <PleaseWait testID="ParkingSessionAddLicensePlatePleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="ParkingSessionAddLicensePlatePleaseWait"
+      />
+    )
   }
 
   return (

--- a/src/modules/parking/components/form/ParkingSessionSelectLicensePlate.tsx
+++ b/src/modules/parking/components/form/ParkingSessionSelectLicensePlate.tsx
@@ -31,7 +31,12 @@ export const ParkingSessionSelectLicensePlate = ({setLicensePlate}: Props) => {
   )
 
   if (isLoading) {
-    return <PleaseWait testID="ParkingSessionSelectLicensePlatePleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="ParkingSessionSelectLicensePlatePleaseWait"
+      />
+    )
   }
 
   if (!activeLicensePlates) {

--- a/src/modules/parking/components/permit-zone/ParkingMachineList.tsx
+++ b/src/modules/parking/components/permit-zone/ParkingMachineList.tsx
@@ -35,7 +35,12 @@ export const ParkingMachineList = () => {
   }
 
   if (!parkingMachinesByDistance?.length || isErrorParkingMachinesData) {
-    return <SomethingWentWrong testID="ParkingMachineListSomethingWentWrong" />
+    return (
+      <SomethingWentWrong
+        inset="md"
+        testID="ParkingMachineListSomethingWentWrong"
+      />
+    )
   }
 
   return (

--- a/src/modules/parking/components/permit-zone/ParkingMachineList.tsx
+++ b/src/modules/parking/components/permit-zone/ParkingMachineList.tsx
@@ -23,6 +23,7 @@ export const ParkingMachineList = () => {
     data: parkingMachinesData,
     isLoading: isLoadingParkingMachinesData,
     isError: isErrorParkingMachinesData,
+    startedTimeStamp,
   } = useParkingMachinesQuery()
 
   const parkingMachinesByDistance = useMemo(
@@ -31,7 +32,12 @@ export const ParkingMachineList = () => {
   )
 
   if (isLoadingParkingMachinesData) {
-    return <PleaseWait testID="ParkingMachineListPleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="ParkingMachineListPleaseWait"
+      />
+    )
   }
 
   if (!parkingMachinesByDistance?.length || isErrorParkingMachinesData) {

--- a/src/modules/parking/components/permit-zone/ParkingMachineSearch.tsx
+++ b/src/modules/parking/components/permit-zone/ParkingMachineSearch.tsx
@@ -37,7 +37,10 @@ export const ParkingMachineSearch = () => {
 
   if (!parkingMachinesData?.length || isErrorParkingMachinesData) {
     return (
-      <SomethingWentWrong testID="ParkingMachineSearchSomethingWentWrong" />
+      <SomethingWentWrong
+        inset="md"
+        testID="ParkingMachineSearchSomethingWentWrong"
+      />
     )
   }
 

--- a/src/modules/parking/components/permit-zone/ParkingMachineSearch.tsx
+++ b/src/modules/parking/components/permit-zone/ParkingMachineSearch.tsx
@@ -19,6 +19,7 @@ export const ParkingMachineSearch = () => {
     data: parkingMachinesData,
     isLoading: isLoadingParkingMachinesData,
     isError: isErrorParkingMachinesData,
+    startedTimeStamp,
   } = useParkingMachinesQuery()
 
   const filteredParkingMachines = useMemo(() => {
@@ -32,7 +33,12 @@ export const ParkingMachineSearch = () => {
   }, [parkingMachinesData, searchTerm])
 
   if (isLoadingParkingMachinesData) {
-    return <PleaseWait testID="ParkingMachineSearchPleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="ParkingMachineSearchPleaseWait"
+      />
+    )
   }
 
   if (!parkingMachinesData?.length || isErrorParkingMachinesData) {

--- a/src/modules/parking/components/permit-zone/ParkingPermitZoneMap.tsx
+++ b/src/modules/parking/components/permit-zone/ParkingPermitZoneMap.tsx
@@ -4,7 +4,6 @@ import {Polygons} from '@/components/features/map/polygon/Polygons'
 import {ControlVariant, MapFocus} from '@/components/features/map/types'
 import {getAllPolygonCoords} from '@/components/features/map/utils/getAllPolygonCoords'
 import {getRegionFromCoords} from '@/components/features/map/utils/getRegionFromCoords'
-import {Box} from '@/components/ui/containers/Box'
 import {PleaseWait} from '@/components/ui/feedback/PleaseWait'
 import {SomethingWentWrong} from '@/components/ui/feedback/SomethingWentWrong'
 import {ModuleSlug} from '@/modules/generated/slugs.generated'
@@ -42,15 +41,16 @@ export const ParkingPermitZoneMap = ({focusType}: {focusType: MapFocus}) => {
   }
 
   if (
-    isError ||
+    !isError ||
     !permitZoneData?.geojson ||
     !('features' in permitZoneData.geojson) ||
     Object.keys(permitZoneData.geojson).length === 0
   ) {
     return (
-      <Box>
-        <SomethingWentWrong testID="ParkingPermitZoneMapSomethingWentWrong" />
-      </Box>
+      <SomethingWentWrong
+        inset="md"
+        testID="ParkingPermitZoneMapSomethingWentWrong"
+      />
     )
   }
 

--- a/src/modules/parking/components/permit-zone/ParkingPermitZoneMap.tsx
+++ b/src/modules/parking/components/permit-zone/ParkingPermitZoneMap.tsx
@@ -24,6 +24,7 @@ export const ParkingPermitZoneMap = ({focusType}: {focusType: MapFocus}) => {
     data: permitZoneData,
     isLoading,
     isError,
+    startedTimeStamp,
   } = usePermitZonesQuery(report_code)
 
   const initialRegion = useMemo(() => {
@@ -37,7 +38,12 @@ export const ParkingPermitZoneMap = ({focusType}: {focusType: MapFocus}) => {
   }, [permitZoneData])
 
   if (isLoading) {
-    return <PleaseWait testID="ParkingPermitZoneMapPleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="ParkingPermitZoneMapPleaseWait"
+      />
+    )
   }
 
   if (

--- a/src/modules/parking/components/permit-zone/ParkingPermitZoneMap.tsx
+++ b/src/modules/parking/components/permit-zone/ParkingPermitZoneMap.tsx
@@ -47,7 +47,7 @@ export const ParkingPermitZoneMap = ({focusType}: {focusType: MapFocus}) => {
   }
 
   if (
-    !isError ||
+    isError ||
     !permitZoneData?.geojson ||
     !('features' in permitZoneData.geojson) ||
     Object.keys(permitZoneData.geojson).length === 0

--- a/src/modules/parking/components/permit-zone/bottomsheet/ParkingMachineBottomSheetContent.tsx
+++ b/src/modules/parking/components/permit-zone/bottomsheet/ParkingMachineBottomSheetContent.tsx
@@ -50,6 +50,7 @@ export const ParkingMachineBottomSheetContent = () => {
     isFetching,
     isError,
     error,
+    startedTimeStamp,
   } = useZoneByMachineQuery(
     selectedParkingMachineId
       ? {
@@ -129,7 +130,10 @@ export const ParkingMachineBottomSheetContent = () => {
                   text="Betaald parkeren"
                 />
                 {isFetching ? (
-                  <PleaseWait testID="ParkingMachineDetailsPleaseWait" />
+                  <PleaseWait
+                    startedTimeStamp={startedTimeStamp}
+                    testID="ParkingMachineDetailsPleaseWait"
+                  />
                 ) : (
                   <Paragraph>
                     {Object.entries(paymentTimes)

--- a/src/modules/parking/components/select-permit/ParkingSelectPermit.tsx
+++ b/src/modules/parking/components/select-permit/ParkingSelectPermit.tsx
@@ -19,7 +19,12 @@ export const ParkingSelectPermit = () => {
   const parkingAccounts = useParkingAccounts()
 
   if (isEmptyObject(parkingAccounts)) {
-    return <SomethingWentWrong testID="ParkingSelectPermitSomethingWentWrong" />
+    return (
+      <SomethingWentWrong
+        inset="md"
+        testID="ParkingSelectPermitSomethingWentWrong"
+      />
+    )
   }
 
   return (

--- a/src/modules/parking/components/session/ParkingActiveSessionsSummary.tsx
+++ b/src/modules/parking/components/session/ParkingActiveSessionsSummary.tsx
@@ -85,7 +85,12 @@ export const ParkingActiveSessionsSummary = () => {
   )
 
   if (isLoading) {
-    return <PleaseWait testID="ParkingPermitSessionsActivePleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="ParkingPermitSessionsActivePleaseWait"
+      />
+    )
   }
 
   if (isError) {

--- a/src/modules/parking/components/session/ParkingPlannedSessionsSummary.tsx
+++ b/src/modules/parking/components/session/ParkingPlannedSessionsSummary.tsx
@@ -67,7 +67,12 @@ export const ParkingPlannedSessionsSummary = () => {
   )
 
   if (isLoading) {
-    return <PleaseWait testID="ParkingPermitSessionsPlannedPleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="ParkingPermitSessionsPlannedPleaseWait"
+      />
+    )
   }
 
   if (isError) {

--- a/src/modules/parking/hooks/useGetPermits.ts
+++ b/src/modules/parking/hooks/useGetPermits.ts
@@ -10,7 +10,10 @@ import {fixPermitNames} from '@/modules/parking/utils/fixPermitNames'
 
 export const useGetPermits = (skip = false) => {
   const dispatch = useDispatch()
-  const {data, isLoading, refetch} = usePermitsQuery({status: 'ACTIVE'}, {skip})
+  const {data, isLoading, refetch, startedTimeStamp} = usePermitsQuery(
+    {status: 'ACTIVE' as const},
+    {skip},
+  )
 
   const currentPermitReportCode = useCurrentParkingPermitReportCode()
   const {setCurrentPermitReportCode, setParkingAccountPermits} =
@@ -40,5 +43,6 @@ export const useGetPermits = (skip = false) => {
     permits,
     isLoading,
     refetch,
+    startedTimeStamp,
   }
 }

--- a/src/modules/parking/providers/CurrentPermitProvider.tsx
+++ b/src/modules/parking/providers/CurrentPermitProvider.tsx
@@ -45,7 +45,10 @@ export const CurrentPermitProvider = ({children}: Props) => {
       <Screen
         bottomSheet={!headerShown}
         testID="ParkingCurrentPermitProviderScreen">
-        <PleaseWait testID="ParkingCurrentPermitProviderPleaseWait" />
+        <PleaseWait
+          showFeedback
+          testID="ParkingCurrentPermitProviderPleaseWait"
+        />
       </Screen>
     )
   }

--- a/src/modules/parking/screens/ParkingDashBoard.screen.tsx
+++ b/src/modules/parking/screens/ParkingDashBoard.screen.tsx
@@ -20,7 +20,7 @@ export const ParkingDashboardScreen = ({route}: Props) => {
   useTransferReduxAccountNameToSecureStorage()
 
   useHandleDeeplink(route)
-  const {permits, isLoading} = useGetPermits()
+  const {permits, isLoading, startedTimeStamp} = useGetPermits()
   const {headerShown = true} = (navigationRef.current?.getCurrentOptions() ??
     {}) as {headerShown?: boolean}
   const isLoggingOut = useParkingAccountIsLoggingOut()
@@ -34,7 +34,10 @@ export const ParkingDashboardScreen = ({route}: Props) => {
           disableHorizontalInsets: true,
         }}
         testID="ParkingDashboardScreen">
-        <PleaseWait testID="ParkingDashboardScreenPleaseWait" />
+        <PleaseWait
+          startedTimeStamp={startedTimeStamp}
+          testID="ParkingDashboardScreenPleaseWait"
+        />
       </Screen>
     )
   }

--- a/src/modules/pride/components/PrideEventDateBottomSheet.tsx
+++ b/src/modules/pride/components/PrideEventDateBottomSheet.tsx
@@ -29,7 +29,7 @@ const options = [
 ]
 
 export const PrideEventDateBottomSheet = () => {
-  const {events, isLoading} = usePrideEvents()
+  const {events, isLoading, startedTimeStamp} = usePrideEvents()
   const dates = Array.from(
     new Set(events?.flatMap(event => [event.date_start, event.date_end]) ?? []),
   )
@@ -76,7 +76,10 @@ export const PrideEventDateBottomSheet = () => {
           />
         )}
         {!!isLoading && (
-          <PleaseWait testID="PrideEventDateBottomSheetPleaseWait" />
+          <PleaseWait
+            startedTimeStamp={startedTimeStamp}
+            testID="PrideEventDateBottomSheetPleaseWait"
+          />
         )}
         <Button
           label="Gereed"

--- a/src/modules/pride/components/PrideEventTypeBottomSheet.tsx
+++ b/src/modules/pride/components/PrideEventTypeBottomSheet.tsx
@@ -12,7 +12,7 @@ import {ALL_TYPES_LABEL} from '@/modules/pride/constants'
 import {usePrideEvents} from '@/modules/pride/hooks/usePrideEvents'
 
 export const PrideEventTypeBottomSheet = () => {
-  const {events, isLoading} = usePrideEvents()
+  const {events, isLoading, startedTimeStamp} = usePrideEvents()
   const options: RadioGroupOption<string, string>[] = useMemo(
     () => [
       {label: ALL_TYPES_LABEL, value: ALL_TYPES_LABEL},
@@ -40,7 +40,10 @@ export const PrideEventTypeBottomSheet = () => {
           testID="PrideEventTypeBottomSheet"
         />
         {!!isLoading && (
-          <PleaseWait testID="PrideEventTypeBottomSheetPleaseWait" />
+          <PleaseWait
+            startedTimeStamp={startedTimeStamp}
+            testID="PrideEventTypeBottomSheetPleaseWait"
+          />
         )}
         <Button
           label="Gereed"

--- a/src/modules/pride/components/PrideEventsList.tsx
+++ b/src/modules/pride/components/PrideEventsList.tsx
@@ -87,7 +87,10 @@ export const PrideEventsList = () => {
           isLoading ? (
             <PleaseWait testID="PrideEventsListPleaseWait" />
           ) : isError ? (
-            <SomethingWentWrong testID="PrideEventsListSomethingWentWrong" />
+            <SomethingWentWrong
+              inset="md"
+              testID="PrideEventsListSomethingWentWrong"
+            />
           ) : undefined
         }
         ListFooterComponent={<Gutter height="xl" />}

--- a/src/modules/pride/components/PrideEventsList.tsx
+++ b/src/modules/pride/components/PrideEventsList.tsx
@@ -29,7 +29,7 @@ import {formatDateToDisplay} from '@/utils/datetime/formatDateToDisplay'
 export const PrideEventsList = () => {
   const {navigate} = useNavigation()
   const {watch} = useFormContext<PrideEventFormValues>()
-  const {events, isLoading, isError} = usePrideEvents()
+  const {events, isLoading, isError, startedTimeStamp} = usePrideEvents()
   const selectedType = watch('type')
   const selectedDate = watch('date')
   const customDate = watch('customDate')
@@ -85,7 +85,10 @@ export const PrideEventsList = () => {
         ItemSeparatorComponent={<Gutter height="md" />}
         ListEmptyComponent={
           isLoading ? (
-            <PleaseWait testID="PrideEventsListPleaseWait" />
+            <PleaseWait
+              startedTimeStamp={startedTimeStamp}
+              testID="PrideEventsListPleaseWait"
+            />
           ) : isError ? (
             <SomethingWentWrong
               inset="md"

--- a/src/modules/pride/screens/PrideEventDetails.screen.tsx
+++ b/src/modules/pride/screens/PrideEventDetails.screen.tsx
@@ -32,7 +32,10 @@ export const PrideEventDetailsScreen = ({route}: Props) => {
 
   if (!event || isError) {
     return (
-      <SomethingWentWrong testID="PrideEventDetailsScreenSomethingWentWrong" />
+      <SomethingWentWrong
+        inset="md"
+        testID="PrideEventDetailsScreenSomethingWentWrong"
+      />
     )
   }
 

--- a/src/modules/pride/screens/PrideEventDetails.screen.tsx
+++ b/src/modules/pride/screens/PrideEventDetails.screen.tsx
@@ -19,7 +19,7 @@ import {formatMeta} from '@/modules/pride/utils/formatMeta'
 type Props = NavigationProps<PrideRouteName.eventDetails>
 
 export const PrideEventDetailsScreen = ({route}: Props) => {
-  const {getEvent, isLoading, isError} = usePrideEvents()
+  const {getEvent, isLoading, isError, startedTimeStamp} = usePrideEvents()
 
   const event = useMemo(
     () => getEvent(route.params.id),
@@ -27,7 +27,12 @@ export const PrideEventDetailsScreen = ({route}: Props) => {
   )
 
   if (isLoading) {
-    return <PleaseWait testID="PrideEventDetailsScreenPleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="PrideEventDetailsScreenPleaseWait"
+      />
+    )
   }
 
   if (!event || isError) {

--- a/src/modules/redirects/components/Redirects.tsx
+++ b/src/modules/redirects/components/Redirects.tsx
@@ -15,7 +15,10 @@ export const Redirects = () => {
   return (
     <Column gutter="md">
       {isLoading ? (
-        <PleaseWait testID="RedirectsPleaseWait" />
+        <PleaseWait
+          showFeedback
+          testID="RedirectsPleaseWait"
+        />
       ) : isError ? (
         <SomethingWentWrong testID="RedirectsSomethingWentWrong" />
       ) : (

--- a/src/modules/service/components/ServicePointList.tsx
+++ b/src/modules/service/components/ServicePointList.tsx
@@ -87,7 +87,12 @@ export const ServicePointList = ({
   }
 
   if (!service || isError) {
-    return <SomethingWentWrong testID="ServicePointListSomethingWentWrong" />
+    return (
+      <SomethingWentWrong
+        inset="md"
+        testID="ServicePointListSomethingWentWrong"
+      />
+    )
   }
 
   return (

--- a/src/modules/service/components/ServicePointList.tsx
+++ b/src/modules/service/components/ServicePointList.tsx
@@ -44,6 +44,7 @@ export const ServicePointList = ({
     data: service,
     isLoading,
     isError,
+    startedTimeStamp,
   } = useServiceQuery(serviceId || skipToken)
   const {data: geojson, icons_to_include: icons} = service || {}
 
@@ -83,7 +84,12 @@ export const ServicePointList = ({
   }, [filteredFeatures, address])
 
   if (isLoading) {
-    return <PleaseWait testID="ServicePointListPleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="ServicePointListPleaseWait"
+      />
+    )
   }
 
   if (!service || isError) {

--- a/src/modules/service/components/ServicePointMap.tsx
+++ b/src/modules/service/components/ServicePointMap.tsx
@@ -37,6 +37,7 @@ export const ServicePointMap = ({
     data: service,
     isLoading,
     isError,
+    startedTimeStamp,
   } = useServiceQuery(serviceId || skipToken)
   const {
     data: {lineStrings, polygons, points},
@@ -61,7 +62,12 @@ export const ServicePointMap = ({
   }, [layers, icons_to_include])
 
   if (isLoading) {
-    return <PleaseWait testID="ServiceMapPleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="ServiceMapPleaseWait"
+      />
+    )
   }
 
   return (

--- a/src/modules/service/components/ServicesGrid.tsx
+++ b/src/modules/service/components/ServicesGrid.tsx
@@ -63,6 +63,7 @@ export const ServicesGrid = ({
     data: serviceMaps,
     isLoading,
     isError,
+    startedTimeStamp,
   } = useServiceOverviewQuery(source)
 
   const coloredServiceMaps = useMemo<
@@ -78,7 +79,12 @@ export const ServicesGrid = ({
   )
 
   if (isLoading) {
-    return <PleaseWait testID="ServiceListPleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="ServiceListPleaseWait"
+      />
+    )
   }
 
   if (!coloredServiceMaps || isError) {

--- a/src/modules/service/components/bottomsheet/ServiceMapLegend.tsx
+++ b/src/modules/service/components/bottomsheet/ServiceMapLegend.tsx
@@ -13,6 +13,7 @@ export const ServiceMapLegend = ({id: serviceId}: {id: Service['id']}) => {
     data: service,
     isLoading,
     isError,
+    startedTimeStamp,
   } = useServiceQuery(serviceId || skipToken)
 
   const items = useMemo(() => {
@@ -59,7 +60,12 @@ export const ServiceMapLegend = ({id: serviceId}: {id: Service['id']}) => {
   }
 
   if (isLoading) {
-    return <PleaseWait testID="ServiceMapLegendPleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="ServiceMapLegendPleaseWait"
+      />
+    )
   }
 
   return (

--- a/src/modules/service/components/bottomsheet/ServiceMapLegend.tsx
+++ b/src/modules/service/components/bottomsheet/ServiceMapLegend.tsx
@@ -2,7 +2,6 @@ import {skipToken} from '@reduxjs/toolkit/query'
 import {useMemo} from 'react'
 import type {Service, ServiceFeature} from '@/modules/service/types'
 import {MapLegend} from '@/components/features/map/MapLegend'
-import {Box} from '@/components/ui/containers/Box'
 import {PleaseWait} from '@/components/ui/feedback/PleaseWait'
 import {SomethingWentWrong} from '@/components/ui/feedback/SomethingWentWrong'
 import {ServicePointCustomIcon} from '@/modules/service/components/ServicePointCustomIcon'
@@ -52,9 +51,10 @@ export const ServiceMapLegend = ({id: serviceId}: {id: Service['id']}) => {
 
   if (isError) {
     return (
-      <Box>
-        <SomethingWentWrong testID="ServiceMapLegendSomethingWentWrong" />
-      </Box>
+      <SomethingWentWrong
+        inset="md"
+        testID="ServiceMapLegendSomethingWentWrong"
+      />
     )
   }
 

--- a/src/modules/survey/components/DynamicForm.tsx
+++ b/src/modules/survey/components/DynamicForm.tsx
@@ -28,7 +28,8 @@ export const DynamicForm = ({entryPoint, showError = false}: Props) => {
   const isInBottomSheet = useIsInBottomSheet()
   const isFeedbackScreen = route.name === UserRouteName.feedback
 
-  const {data, isFetching, isError} = useSurveyConfigByLocationQuery(entryPoint)
+  const {data, isFetching, isError, startedTimeStamp} =
+    useSurveyConfigByLocationQuery(entryPoint)
   const {survey, id: surveyId} = data ?? {}
   const {
     onSubmit,
@@ -44,7 +45,12 @@ export const DynamicForm = ({entryPoint, showError = false}: Props) => {
   })
 
   if (isFetching) {
-    return <PleaseWait testID="DynamicFormPleaseWait" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="DynamicFormPleaseWait"
+      />
+    )
   }
 
   if (isError) {

--- a/src/modules/user/components/module-settings/ModuleSettings.tsx
+++ b/src/modules/user/components/module-settings/ModuleSettings.tsx
@@ -18,6 +18,7 @@ export const ModuleSettings = () => {
     return (
       <PleaseWait
         grow
+        showFeedback
         testID="UserModuleSettingsLoadingSpinner"
       />
     )

--- a/src/modules/user/components/notification-settings/NotificationSettings.tsx
+++ b/src/modules/user/components/notification-settings/NotificationSettings.tsx
@@ -71,7 +71,12 @@ export const NotificationSettings = () => {
     )
 
   if (isLoadingModules || isLoadingDisabledPushModules) {
-    return <PleaseWait testID="NotificationSettingsPleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="NotificationSettingsPleaseWait"
+      />
+    )
   }
 
   if (!notificationModules || !disabledPushModules) {

--- a/src/modules/waste-guide/components/WasteGuide.tsx
+++ b/src/modules/waste-guide/components/WasteGuide.tsx
@@ -21,7 +21,12 @@ export const WasteGuide = () => {
   }
 
   if (isFetchingAddress || isFetchingWasteGuide) {
-    return <PleaseWait testID="WasteGuideLoadingSpinner" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="WasteGuideLoadingSpinner"
+      />
+    )
   }
 
   if (loadingError) {

--- a/src/modules/waste-guide/components/calendar/WasteGuideCalendar.tsx
+++ b/src/modules/waste-guide/components/calendar/WasteGuideCalendar.tsx
@@ -21,7 +21,12 @@ export const WasteGuideCalendar = () => {
   }
 
   if (isLoading) {
-    return <PleaseWait testID="WasteGuideCalendarListViewPleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="WasteGuideCalendarListViewPleaseWait"
+      />
+    )
   }
 
   if (getWasteGuideIsError || !wasteGuide) {

--- a/src/modules/waste-guide/components/calendar/WasteGuideCalendar.tsx
+++ b/src/modules/waste-guide/components/calendar/WasteGuideCalendar.tsx
@@ -13,6 +13,7 @@ export const WasteGuideCalendar = () => {
   if (!address) {
     return (
       <SomethingWentWrong
+        inset="md"
         testID="WasteGuideCalendarListViewNoAddressSomethingWentWrong"
         text="Er is geen geldig adres geselecteerd. Ga naar Mijn profiel om een adres toe te voegen."
       />
@@ -26,6 +27,7 @@ export const WasteGuideCalendar = () => {
   if (getWasteGuideIsError || !wasteGuide) {
     return (
       <SomethingWentWrong
+        inset="md"
         testID="WasteGuideCalendarListViewSomethingWentWrong"
         text="Er is iets misgegaan bij het ophalen van de afvalkalender."
       />

--- a/src/modules/waste-guide/components/recyclepoints/WasteGuideRecyclePoint.tsx
+++ b/src/modules/waste-guide/components/recyclepoints/WasteGuideRecyclePoint.tsx
@@ -15,7 +15,12 @@ export const WasteGuideRecyclePoint = () => {
   const {activeRecyclePoint, isLoading} = useGetActiveRecyclePoint()
 
   if (isLoading) {
-    return <PleaseWait testID="WasteGuideRecyclePointsPleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="WasteGuideRecyclePointsPleaseWait"
+      />
+    )
   }
 
   if (!activeRecyclePoint) {

--- a/src/modules/waste-guide/components/recyclepoints/WasteGuideRecyclePointMap.tsx
+++ b/src/modules/waste-guide/components/recyclepoints/WasteGuideRecyclePointMap.tsx
@@ -37,7 +37,10 @@ export const WasteGuideRecyclePointMap = () => {
 
   if (!coordinates) {
     return (
-      <SomethingWentWrong testID="WasteGuideRecyclePointMapSomethingWentWrong" />
+      <SomethingWentWrong
+        inset="md"
+        testID="WasteGuideRecyclePointMapSomethingWentWrong"
+      />
     )
   }
 

--- a/src/modules/waste-guide/components/recyclepoints/WasteGuideRecyclePointMap.tsx
+++ b/src/modules/waste-guide/components/recyclepoints/WasteGuideRecyclePointMap.tsx
@@ -30,7 +30,12 @@ export const WasteGuideRecyclePointMap = () => {
   useSetScreenTitle(recyclePoint?.name)
 
   if (isLoading) {
-    return <PleaseWait testID="WasteGuideRecyclePointMapPleaseWait" />
+    return (
+      <PleaseWait
+        showFeedback
+        testID="WasteGuideRecyclePointMapPleaseWait"
+      />
+    )
   }
 
   const coordinates = recyclePoint?.address.coordinates

--- a/src/modules/waste-guide/components/recyclepoints/WasteGuideSelectRecyclePoint.tsx
+++ b/src/modules/waste-guide/components/recyclepoints/WasteGuideSelectRecyclePoint.tsx
@@ -12,7 +12,11 @@ import {useActiveRecyclePointId} from '@/modules/waste-guide/slice'
 
 export const WasteGuideSelectRecyclePoint = () => {
   const focusRef = useSetBottomSheetElementFocus()
-  const {data: recyclePoints, isLoading} = useGetWasteGuideRecyclePointsQuery()
+  const {
+    data: recyclePoints,
+    isLoading,
+    startedTimeStamp,
+  } = useGetWasteGuideRecyclePointsQuery()
   const {setActiveRecyclePointId} = useActiveRecyclePointId()
   const {close} = useBottomSheet()
 
@@ -25,7 +29,12 @@ export const WasteGuideSelectRecyclePoint = () => {
   )
 
   if (isLoading) {
-    return <PleaseWait testID="WasteGuideSelectRecyclePointsLoadingSpinner" />
+    return (
+      <PleaseWait
+        startedTimeStamp={startedTimeStamp}
+        testID="WasteGuideSelectRecyclePointsLoadingSpinner"
+      />
+    )
   }
 
   if (!recyclePoints) {

--- a/src/modules/waste-guide/components/recyclepoints/WasteGuideSelectRecyclePoint.tsx
+++ b/src/modules/waste-guide/components/recyclepoints/WasteGuideSelectRecyclePoint.tsx
@@ -30,7 +30,10 @@ export const WasteGuideSelectRecyclePoint = () => {
 
   if (!recyclePoints) {
     return (
-      <SomethingWentWrong testID="WasteGuideSelectRecyclePointsSomethingWentWrong" />
+      <SomethingWentWrong
+        inset="md"
+        testID="WasteGuideSelectRecyclePointsSomethingWentWrong"
+      />
     )
   }
 

--- a/src/modules/waste-guide/screenConfig.ts
+++ b/src/modules/waste-guide/screenConfig.ts
@@ -45,6 +45,9 @@ export const screenConfig: StackNavigationRoutes<
   [WasteGuideRouteName.wasteGuideRecyclePointMap]: {
     component: WasteGuideRecyclePointMapScreen,
     name: WasteGuideRouteName.wasteGuideRecyclePointMap,
+    options: {
+      headerShown: false,
+    },
   },
   [WasteGuideRouteName.wasteGuideRecyclePoints]: {
     component: WasteGuideRecyclePointsScreen,


### PR DESCRIPTION
# Changes

## Pull request overview

This PR extends the app’s loading experience by enhancing the shared `PleaseWait` component with optional “long wait” textual feedback (timer-based), and then wiring that enhanced feedback into many module loading states for a more informative UX during slow network calls.

**Changes:**
- Enhanced `PleaseWait` to optionally display timed feedback based on either RTK Query `startedTimeStamp` or a mount-based timer (`showFeedback`).
- Updated many screens/components to pass `startedTimeStamp` or `showFeedback` to `PleaseWait`, and added consistent `inset="md"` usage for `SomethingWentWrong` in several places.
- Hid stack headers for a few routes where full-screen presentation is desired.

## Test instructions

## Other notes